### PR TITLE
[BE] 코드 컨벤션 작성 및 imports문 정렬

### DIFF
--- a/backend/Momo_CodeStyle.xml
+++ b/backend/Momo_CodeStyle.xml
@@ -1,0 +1,80 @@
+<code_scheme name="Momo-CodeStyle" version="173">
+  <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+  <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+  <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+  <option name="CALL_PARAMETERS_WRAP" value="1" />
+  <option name="METHOD_PARAMETERS_WRAP" value="1" />
+  <option name="EXTENDS_LIST_WRAP" value="1" />
+  <option name="THROWS_KEYWORD_WRAP" value="1" />
+  <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+  <option name="BINARY_OPERATION_WRAP" value="1" />
+  <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+  <option name="TERNARY_OPERATION_WRAP" value="1" />
+  <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+  <option name="FOR_STATEMENT_WRAP" value="1" />
+  <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+  <option name="WRAP_COMMENTS" value="true" />
+  <option name="IF_BRACE_FORCE" value="3" />
+  <option name="DOWHILE_BRACE_FORCE" value="3" />
+  <option name="WHILE_BRACE_FORCE" value="3" />
+  <option name="FOR_BRACE_FORCE" value="3" />
+  <JavaCodeStyleSettings>
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+      <value />
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="java" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="javax" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="org" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="net" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="com" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="com.woowacourse" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="java" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="javax" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="org" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="net" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="com" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="com.woowacourse" withSubpackages="true" static="false" />
+      </value>
+    </option>
+  </JavaCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="WRAP_COMMENTS" value="true" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+  </codeStyleSettings>
+</code_scheme>

--- a/backend/src/main/java/com/woowacourse/momo/controller/CategoryController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/CategoryController.java
@@ -1,14 +1,16 @@
 package com.woowacourse.momo.controller;
 
-import com.woowacourse.momo.service.CategoryService;
-import com.woowacourse.momo.service.dto.CategoryResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+import com.woowacourse.momo.service.CategoryService;
+import com.woowacourse.momo.service.dto.CategoryResponse;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/categories")

--- a/backend/src/main/java/com/woowacourse/momo/controller/GroupController.java
+++ b/backend/src/main/java/com/woowacourse/momo/controller/GroupController.java
@@ -1,15 +1,24 @@
 package com.woowacourse.momo.controller;
 
+import java.net.URI;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
 import com.woowacourse.momo.service.GroupService;
 import com.woowacourse.momo.service.dto.request.GroupRequest;
 import com.woowacourse.momo.service.dto.request.GroupUpdateRequest;
 import com.woowacourse.momo.service.dto.response.GroupResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")

--- a/backend/src/main/java/com/woowacourse/momo/domain/category/Category.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/category/Category.java
@@ -1,9 +1,13 @@
 package com.woowacourse.momo.domain.category;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/domain/group/Day.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/group/Day.java
@@ -1,8 +1,8 @@
 package com.woowacourse.momo.domain.group;
 
-import lombok.Getter;
-
 import java.util.Arrays;
+
+import lombok.Getter;
 
 @Getter
 public enum Day {

--- a/backend/src/main/java/com/woowacourse/momo/domain/group/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/group/Duration.java
@@ -1,11 +1,12 @@
 package com.woowacourse.momo.domain.group;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.time.LocalDate;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
-import java.time.LocalDate;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/group/Group.java
@@ -1,12 +1,19 @@
 package com.woowacourse.momo.domain.group;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/domain/group/Schedule.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/group/Schedule.java
@@ -1,11 +1,21 @@
 package com.woowacourse.momo.domain.group;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/domain/group/Schedules.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/group/Schedules.java
@@ -1,14 +1,15 @@
 package com.woowacourse.momo.domain.group;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable

--- a/backend/src/main/java/com/woowacourse/momo/domain/member/Member.java
+++ b/backend/src/main/java/com/woowacourse/momo/domain/member/Member.java
@@ -1,9 +1,13 @@
 package com.woowacourse.momo.domain.member;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/repository/CategoryRepository.java
@@ -1,7 +1,8 @@
 package com.woowacourse.momo.repository;
 
-import com.woowacourse.momo.domain.category.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.woowacourse.momo.domain.category.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/backend/src/main/java/com/woowacourse/momo/repository/GroupRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/repository/GroupRepository.java
@@ -1,7 +1,8 @@
 package com.woowacourse.momo.repository;
 
-import com.woowacourse.momo.domain.group.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.woowacourse.momo.domain.group.Group;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
 }

--- a/backend/src/main/java/com/woowacourse/momo/repository/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/repository/MemberRepository.java
@@ -1,7 +1,8 @@
 package com.woowacourse.momo.repository;
 
-import com.woowacourse.momo.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.woowacourse.momo.domain.member.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/backend/src/main/java/com/woowacourse/momo/service/CategoryService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/CategoryService.java
@@ -1,14 +1,16 @@
 package com.woowacourse.momo.service;
 
-import com.woowacourse.momo.domain.category.Category;
-import com.woowacourse.momo.repository.CategoryRepository;
-import com.woowacourse.momo.service.dto.CategoryResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+import com.woowacourse.momo.domain.category.Category;
+import com.woowacourse.momo.repository.CategoryRepository;
+import com.woowacourse.momo.service.dto.CategoryResponse;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/momo/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/GroupService.java
@@ -1,5 +1,13 @@
 package com.woowacourse.momo.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
 import com.woowacourse.momo.domain.group.Group;
 import com.woowacourse.momo.domain.group.Schedule;
 import com.woowacourse.momo.domain.member.Member;
@@ -9,13 +17,6 @@ import com.woowacourse.momo.service.dto.request.GroupRequest;
 import com.woowacourse.momo.service.dto.request.GroupUpdateRequest;
 import com.woowacourse.momo.service.dto.request.ScheduleRequest;
 import com.woowacourse.momo.service.dto.response.GroupResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/CategoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/CategoryResponse.java
@@ -1,8 +1,9 @@
 package com.woowacourse.momo.service.dto;
 
-import com.woowacourse.momo.domain.category.Category;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import com.woowacourse.momo.domain.category.Category;
 
 @Getter
 @AllArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/request/DurationRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/request/DurationRequest.java
@@ -1,12 +1,14 @@
 package com.woowacourse.momo.service.dto.request;
 
-import com.woowacourse.momo.domain.group.Duration;
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
+import com.woowacourse.momo.domain.group.Duration;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/request/GroupRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/request/GroupRequest.java
@@ -1,15 +1,17 @@
 package com.woowacourse.momo.service.dto.request;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.woowacourse.momo.domain.group.Group;
-import com.woowacourse.momo.domain.group.Schedule;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.woowacourse.momo.domain.group.Group;
+import com.woowacourse.momo.domain.group.Schedule;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/request/GroupUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/request/GroupUpdateRequest.java
@@ -1,15 +1,13 @@
 package com.woowacourse.momo.service.dto.request;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.woowacourse.momo.domain.group.Group;
-import com.woowacourse.momo.domain.group.Schedule;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/request/ScheduleRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/request/ScheduleRequest.java
@@ -1,9 +1,10 @@
 package com.woowacourse.momo.service.dto.request;
 
-import com.woowacourse.momo.domain.group.Schedule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.woowacourse.momo.domain.group.Schedule;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/request/TimeRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/request/TimeRequest.java
@@ -1,11 +1,12 @@
 package com.woowacourse.momo.service.dto.request;
 
+import java.time.LocalTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/response/DurationResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/response/DurationResponse.java
@@ -1,12 +1,14 @@
 package com.woowacourse.momo.service.dto.response;
 
-import com.woowacourse.momo.domain.group.Duration;
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.LocalDate;
+import com.woowacourse.momo.domain.group.Duration;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/response/GroupResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/response/GroupResponse.java
@@ -1,17 +1,19 @@
 package com.woowacourse.momo.service.dto.response;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.woowacourse.momo.domain.group.Group;
-import com.woowacourse.momo.domain.group.Schedules;
-import com.woowacourse.momo.domain.member.Member;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.woowacourse.momo.domain.group.Group;
+import com.woowacourse.momo.domain.group.Schedules;
+import com.woowacourse.momo.domain.member.Member;
 
 @Getter
 @Builder

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/response/MemberResponse.java
@@ -1,8 +1,9 @@
 package com.woowacourse.momo.service.dto.response;
 
-import com.woowacourse.momo.domain.member.Member;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import com.woowacourse.momo.domain.member.Member;
 
 @Getter
 @AllArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/response/ScheduleResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/response/ScheduleResponse.java
@@ -1,9 +1,10 @@
 package com.woowacourse.momo.service.dto.response;
 
-import com.woowacourse.momo.domain.group.Schedule;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.woowacourse.momo.domain.group.Schedule;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/service/dto/response/TimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/service/dto/response/TimeResponse.java
@@ -1,11 +1,12 @@
 package com.woowacourse.momo.service.dto.response;
 
+import java.time.LocalTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalTime;
 
 @Getter
 @NoArgsConstructor

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/AcceptanceTest.java
@@ -1,10 +1,11 @@
 package com.woowacourse.momo.acceptance;
 
-import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/CategoryAcceptanceTest.java
@@ -1,13 +1,13 @@
 package com.woowacourse.momo.acceptance;
 
+import static org.hamcrest.Matchers.is;
+
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
-
-import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings("NonAsciiCharacters")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/GroupAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/GroupAcceptanceTest.java
@@ -1,10 +1,12 @@
 package com.woowacourse.momo.acceptance;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
-
-import static org.hamcrest.Matchers.*;
 
 @Sql("classpath:init.sql")
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/RestAssuredConvenienceMethod.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/RestAssuredConvenienceMethod.java
@@ -1,8 +1,9 @@
 package com.woowacourse.momo.acceptance;
 
+import org.springframework.http.MediaType;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ValidatableResponse;
-import org.springframework.http.MediaType;
 
 public class RestAssuredConvenienceMethod {
 

--- a/backend/src/test/java/com/woowacourse/momo/domain/group/DurationTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/domain/group/DurationTest.java
@@ -1,15 +1,15 @@
 package com.woowacourse.momo.domain.group;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class DurationTest {
 

--- a/backend/src/test/java/com/woowacourse/momo/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/repository/CategoryRepositoryTest.java
@@ -1,15 +1,16 @@
 package com.woowacourse.momo.repository;
 
-import com.woowacourse.momo.domain.category.Category;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.woowacourse.momo.domain.category.Category;
 
 @DataJpaTest
 class CategoryRepositoryTest {

--- a/backend/src/test/java/com/woowacourse/momo/repository/GroupRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/repository/GroupRepositoryTest.java
@@ -1,12 +1,6 @@
 package com.woowacourse.momo.repository;
 
-import com.woowacourse.momo.domain.group.Duration;
-import com.woowacourse.momo.domain.group.Group;
-import com.woowacourse.momo.domain.group.Schedule;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,7 +9,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.woowacourse.momo.domain.group.Duration;
+import com.woowacourse.momo.domain.group.Group;
+import com.woowacourse.momo.domain.group.Schedule;
 
 @DataJpaTest
 class GroupRepositoryTest {

--- a/backend/src/test/java/com/woowacourse/momo/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/repository/MemberRepositoryTest.java
@@ -1,14 +1,15 @@
 package com.woowacourse.momo.repository;
 
-import com.woowacourse.momo.domain.member.Member;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.woowacourse.momo.domain.member.Member;
 
 @DataJpaTest
 class MemberRepositoryTest {

--- a/backend/src/test/java/com/woowacourse/momo/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/service/CategoryServiceTest.java
@@ -1,17 +1,18 @@
 package com.woowacourse.momo.service;
 
-import com.woowacourse.momo.domain.category.Category;
-import com.woowacourse.momo.repository.CategoryRepository;
-import com.woowacourse.momo.service.dto.CategoryResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.woowacourse.momo.domain.category.Category;
+import com.woowacourse.momo.repository.CategoryRepository;
+import com.woowacourse.momo.service.dto.CategoryResponse;
 
 @SpringBootTest
 class CategoryServiceTest {


### PR DESCRIPTION
issue #29 
close #29 

---
코드 컨벤션의 기본 템플릿은 [캠퍼스 핵데이 Java 코딩 컨벤션](https://naver.github.io/hackday-conventions-java/)을 따랐으며,
import 선언 순서 부분을 아래와 같이 수정하였습니다.

- import 구절은 아래와 같은 순서로 그룹을 묶어서 선언한다.
- 각 그룹 사이에는 빈줄을 삽입한다. 같은 그룹 내에서는 알파벳 순으로 정렬한다.

```
 1. static import java.

 2. static import javax.

 3. static import org.

 4. static import net.

 5. static import com.*

 6. static import *

 7. static import com.woowacourse.

 8. import java.

 9. import javax.

10. import org.

11. import net.

12. import com.*

13. import *

14. import com.woowacourse.

```

---

### Intellij 설정 적용 방법
`Settings > Editor > Code Style > Java` 설정에서
`Scheme > import Scheme > Intellij IDEA code style XML` 를 클릭 후
`/backend/Momo_CodeStyle.xml` 를 선택하여 적용

![image](https://user-images.githubusercontent.com/22176552/178098533-ba634fcc-c01c-4122-9f55-2b104cb250ea.png)
