### PR TITLE
[BE] 모임 API 기능 - 일부 인수테스트가 통과하지 않는 이슈

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,9 +11,6 @@ spring:
       ddl-auto: create
       naming:
         physical-strategy: com.woowacourse.momo.CustomNamingStrategy
-  h2:
-    console:
-      enable: 'true'
 logging:
   level:
     org:

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/AcceptanceTest.java
@@ -3,12 +3,10 @@ package com.woowacourse.momo.acceptance;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
 public class AcceptanceTest {
 
     @Value("${local.server.port}")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/CategoryAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/CategoryAcceptanceTest.java
@@ -4,13 +4,11 @@ import static org.hamcrest.Matchers.is;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 
 @SuppressWarnings("NonAsciiCharacters")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Sql("classpath:init.sql")
 class CategoryAcceptanceTest extends AcceptanceTest {
 

--- a/backend/src/test/resources/init.sql
+++ b/backend/src/test/resources/init.sql
@@ -1,8 +1,54 @@
-truncate table momo_category;
+drop table if exists momo_category CASCADE;
+drop table if exists momo_group CASCADE;
+drop table if exists momo_member CASCADE;
+drop table if exists momo_schedule CASCADE;
 
-insert into momo_category (name) values
-    ('운동'), ('스터디'), ('한 잔'), ('영화'), ('모각코');
+create table momo_category
+(
+    id   bigint auto_increment,
+    name varchar(30) not null,
+    primary key (id)
+);
 
-truncate table momo_member;
+create table momo_group
+(
+    id         bigint auto_increment,
+    categoryId bigint       not null,
+    deadline   timestamp    not null,
+    description clob not null,
+    endDate    date         not null,
+    startDate  date         not null,
+    hostId     bigint       not null,
+    location   varchar(255) not null,
+    name       varchar(255) not null,
+    regular    boolean      not null,
+    primary key (id)
+);
 
-insert into momo_member (name) values ('momo');
+create table momo_member
+(
+    id   bigint auto_increment,
+    name varchar(30) not null,
+    primary key (id)
+);
+
+create table momo_schedule
+(
+    id             bigint auto_increment,
+    endTime        time not null,
+    reservationDay varchar(255),
+    startTime      time not null,
+    group_id       bigint,
+    primary key (id)
+);
+
+
+INSERT INTO momo_category (name)
+VALUES ('운동'),
+       ('스터디'),
+       ('한 잔'),
+       ('영화'),
+       ('모각코');
+
+INSERT INTO momo_member (name)
+VALUES ('momo');


### PR DESCRIPTION
close #31

### 문제 상황

- 인수테스트의 단일 실행은 통과되나, 전체 실행에서 아래의 테스트가 통과되지 않는 이슈 발생
  - 카테고리 목록 조회
  - 모임 단일 조회
  - 모임 전체 조회

### 원인 분석

- `init.sql` 파일의 DB 초기화 방식에 문제가 있음을 확인.

### 해결

- Truncate를 통해 초기화 하던 기존의 방식을, Drop-Create 방식으로 대체