### PR TITLE
[BE] 스프링부트 버전 오류 & DB 설정 이슈 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.7.1'
+	id 'org.springframework.boot' version '2.6.9'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,12 +1,14 @@
 spring:
   datasource:
     username: sa
-    url: jdbc:h2:~/test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:~/momo;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
     properties:
       hibernate:
         format_sql: 'true'
+        dialect: org.hibernate.dialect.H2Dialect
     show-sql: 'true'
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
       ddl-auto: create
       naming:


### PR DESCRIPTION
Issue #38 

# 이슈
인텔리제이가 스프링부트 버전 2.7.1에서 MockMvc, ObjectMapper등의 빈들을 등록하지 못하는 이슈가 있었다.

# 해결
스프링부트 버전을 2.6.9로 다운그레이드하였다. 