### PR TITLE
[BE] 타회원이 주최한 모임의 정보를 수정 및 삭제할 수 있는 이슈 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/controller/GroupController.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/controller/GroupController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.config.Authenticated;
+import com.woowacourse.momo.auth.config.AuthenticationPrincipal;
 import com.woowacourse.momo.group.service.GroupService;
 import com.woowacourse.momo.group.service.dto.request.GroupRequest;
 import com.woowacourse.momo.group.service.dto.request.GroupUpdateRequest;
@@ -31,8 +32,9 @@ public class GroupController {
 
     @Authenticated
     @PostMapping
-    public ResponseEntity<GroupIdResponse> create(@RequestBody GroupRequest groupRequest) {
-        GroupIdResponse groupIdResponse = groupService.create(groupRequest);
+    public ResponseEntity<GroupIdResponse> create(@AuthenticationPrincipal Long memberId,
+                                                  @RequestBody GroupRequest groupRequest) {
+        GroupIdResponse groupIdResponse = groupService.create(memberId, groupRequest);
         return ResponseEntity.created(URI.create("/api/groups/" + groupIdResponse.getGroupId()))
                 .body(groupIdResponse);
     }
@@ -49,15 +51,16 @@ public class GroupController {
 
     @Authenticated
     @PutMapping("/{groupId}")
-    public ResponseEntity<Void> update(@PathVariable Long groupId, @RequestBody GroupUpdateRequest groupUpdateRequest) {
-        groupService.update(groupId, groupUpdateRequest);
+    public ResponseEntity<Void> update(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId,
+                                       @RequestBody GroupUpdateRequest groupUpdateRequest) {
+        groupService.update(memberId, groupId, groupUpdateRequest);
         return ResponseEntity.ok().build();
     }
 
     @Authenticated
     @DeleteMapping("/{groupId}")
-    public ResponseEntity<Void> delete(@PathVariable Long groupId) {
-        groupService.delete(groupId);
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId) {
+        groupService.delete(memberId, groupId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -26,9 +26,9 @@ import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.category.domain.Category;
 import com.woowacourse.momo.group.domain.duration.Duration;
-import com.woowacourse.momo.participant.domain.Participant;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
 import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.participant.domain.Participant;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -98,6 +98,10 @@ public class Group {
         belongTo(schedules);
     }
 
+    public boolean equalsHost(Member host) {
+        return Objects.equals(this.hostId, host.getId());
+    }
+
     public void participate(Member member) {
         this.participants.add(new Participant(this, member));
     }
@@ -121,7 +125,6 @@ public class Group {
         private String name;
         private Long hostId;
         private Category category;
-        private List<Participant> participants;
         private Duration duration;
         private LocalDateTime deadline;
         private List<Schedule> schedules;
@@ -148,11 +151,6 @@ public class Group {
 
         public Builder categoryId(long categoryId) {
             this.category = Category.from(categoryId);
-            return this;
-        }
-
-        public Builder participants(List<Participant> participants) {
-            this.participants = participants;
             return this;
         }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -98,7 +98,7 @@ public class Group {
         belongTo(schedules);
     }
 
-    public boolean equalsHost(Member host) {
+    public boolean isSameHost(Member host) {
         return Objects.equals(this.hostId, host.getId());
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -79,7 +79,7 @@ public class GroupService {
 
     private void validateHost(Group group, Long hostId) {
         Member host = memberFindService.findMember(hostId);
-        if (!group.equalsHost(host)) {
+        if (!group.isSameHost(host)) {
             throw new IllegalArgumentException("해당 모임의 주최자가 아닙니다.");
         }
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequest.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 public class GroupRequest {
 
     private String name;
-    private Long hostId;
     private Long categoryId;
     private DurationRequest duration;
     private List<ScheduleRequest> schedules;

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequestAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequestAssembler.java
@@ -9,14 +9,15 @@ import lombok.NoArgsConstructor;
 import com.woowacourse.momo.group.domain.duration.Duration;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
+import com.woowacourse.momo.member.domain.Member;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GroupRequestAssembler {
 
-    public static Group group(GroupRequest request) {
+    public static Group group(Member host, GroupRequest request) {
         return new Group.Builder()
                 .name(request.getName())
-                .hostId(request.getHostId())
+                .hostId(host.getId())
                 .categoryId(request.getCategoryId())
                 .duration(duration(request.getDuration()))
                 .deadline(request.getDeadline())

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
@@ -69,7 +69,7 @@ public class GroupControllerTest {
     void groupCreateTest() throws Exception {
         Long saveMemberId = saveMember();
         String accessToken = accessToken();
-        GroupRequest groupRequest = new GroupRequest("모모의 스터디", saveMemberId, 1L, DURATION_REQUEST,
+        GroupRequest groupRequest = new GroupRequest("모모의 스터디", 1L, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
         mockMvc.perform(post("/api/groups/")
@@ -152,10 +152,10 @@ public class GroupControllerTest {
     }
 
     Long saveGroup(Long hostId) {
-        GroupRequest groupRequest = new GroupRequest("모모의 스터디", hostId, 1L, DURATION_REQUEST,
+        GroupRequest groupRequest = new GroupRequest("모모의 스터디", 1L, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
-        return groupService.create(groupRequest).getGroupId();
+        return groupService.create(hostId, groupRequest).getGroupId();
     }
 
     String accessToken() {

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -67,10 +67,10 @@ class GroupServiceTest {
     @DisplayName("모임을 생성한다")
     @Test
     void create() {
-        GroupRequest request = new GroupRequest("모모의 스터디", savedMember.getId(), Category.STUDY.getId(),
+        GroupRequest request = new GroupRequest("모모의 스터디", Category.STUDY.getId(),
                 DURATION_REQUEST, SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
-        groupService.create(request);
+        groupService.create(savedMember.getId(), request);
 
         assertThat(groupRepository.findAll()).hasSize(1);
     }
@@ -79,10 +79,10 @@ class GroupServiceTest {
     @Test
     void createWithInvalidCategoryId() {
         Long categoryId = 0L;
-        GroupRequest request = new GroupRequest("모모의 스터디", savedMember.getId(), categoryId, DURATION_REQUEST,
+        GroupRequest request = new GroupRequest("모모의 스터디", categoryId, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
-        assertThatThrownBy(() -> groupService.create(request))
+        assertThatThrownBy(() -> groupService.create(savedMember.getId(), request))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("카테고리를 찾을 수 없습니다.");
     }
@@ -125,7 +125,7 @@ class GroupServiceTest {
     @Test
     void delete() {
         long groupId = saveGroup().getId();
-        groupService.delete(groupId);
+        groupService.delete(savedMember.getId(), groupId);
 
         assertThatThrownBy(() -> groupService.findById(groupId))
                 .isInstanceOf(NotFoundGroupException.class);

--- a/backend/src/test/java/com/woowacourse/momo/participant/acceptance/ParticipantAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/acceptance/ParticipantAcceptanceTest.java
@@ -65,8 +65,9 @@ public class ParticipantAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 비회원은_모임에_참여할_수_없다() {
+        long groupId = 생성한_모임_아이디();
         탈퇴한다(token);
-        ExtractableResponse<Response> response = 모임에_참여한다(token, 생성한_모임_아이디());
+        ExtractableResponse<Response> response = 모임에_참여한다(token, groupId);
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),


### PR DESCRIPTION
close #87 

### 문제 원인
- GroupController에서 모임 수정 및 삭제 기능에서
- `@Authenticated` 를 통해 토큰 검증만 수행하고 있음. (로그인 여부만 확인)

### 문제 해결
- GroupController의 모임 수정 및 삭제 기능에서
- `@AuthenticationPrincipal`를 통해 토큰으로부터 사용자 ID를 받아와
- 모임의 주최자인지 확인하는 검증 로직을 GroupService에 추가함.

### 추가 사항
- 모임 생성 API 변경 사항 적용 (hostId 제거) 및 그에 따른 로직 수정