### PR TITLE
[BE] CORS 및 RestDocs 경로 패턴 설정 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
@@ -27,12 +27,4 @@ public class AuthConfiguration implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new TokenResolver(jwtTokenProvider));
     }
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("*")
-                .allowedMethods("*")
-                .maxAge(3000);
-    }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,7 +19,8 @@ public class AuthConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new AuthInterceptor(jwtTokenProvider));
+        registry.addInterceptor(new AuthInterceptor(jwtTokenProvider))
+                .addPathPatterns("/api/**");
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -26,10 +26,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         if (CorsUtils.isPreFlightRequest(request)) {
             return true;
         }
-        String uri = request.getRequestURI();
-        if (uri.startsWith("/docs")) {
-            return true;
-        }
+
         Optional<Authenticated> authenticated = parseAnnotation((HandlerMethod) handler, Authenticated.class);
         if (authenticated.isPresent()) {
             validateToken(request);

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -22,6 +23,9 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
         String uri = request.getRequestURI();
         if (uri.startsWith("/docs")) {
             return true;

--- a/backend/src/main/java/com/woowacourse/momo/config/GlobalWebConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/GlobalWebConfiguration.java
@@ -5,7 +5,7 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
+public class GlobalWebConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/backend/src/main/java/com/woowacourse/momo/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.woowacourse.momo.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedMethods("*")
+                .maxAge(3000);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/config/WebConfig.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedMethods("*")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .maxAge(3000);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/controller/GroupController.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/controller/GroupController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.config.Authenticated;
+import com.woowacourse.momo.auth.config.AuthenticationPrincipal;
 import com.woowacourse.momo.group.service.GroupService;
 import com.woowacourse.momo.group.service.dto.request.GroupRequest;
 import com.woowacourse.momo.group.service.dto.request.GroupUpdateRequest;
@@ -31,8 +32,9 @@ public class GroupController {
 
     @Authenticated
     @PostMapping
-    public ResponseEntity<GroupIdResponse> create(@RequestBody GroupRequest groupRequest) {
-        GroupIdResponse groupIdResponse = groupService.create(groupRequest);
+    public ResponseEntity<GroupIdResponse> create(@AuthenticationPrincipal Long memberId,
+                                                  @RequestBody GroupRequest groupRequest) {
+        GroupIdResponse groupIdResponse = groupService.create(memberId, groupRequest);
         return ResponseEntity.created(URI.create("/api/groups/" + groupIdResponse.getGroupId()))
                 .body(groupIdResponse);
     }
@@ -49,15 +51,16 @@ public class GroupController {
 
     @Authenticated
     @PutMapping("/{groupId}")
-    public ResponseEntity<Void> update(@PathVariable Long groupId, @RequestBody GroupUpdateRequest groupUpdateRequest) {
-        groupService.update(groupId, groupUpdateRequest);
+    public ResponseEntity<Void> update(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId,
+                                       @RequestBody GroupUpdateRequest groupUpdateRequest) {
+        groupService.update(memberId, groupId, groupUpdateRequest);
         return ResponseEntity.ok().build();
     }
 
     @Authenticated
     @DeleteMapping("/{groupId}")
-    public ResponseEntity<Void> delete(@PathVariable Long groupId) {
-        groupService.delete(groupId);
+    public ResponseEntity<Void> delete(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId) {
+        groupService.delete(memberId, groupId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -26,9 +26,9 @@ import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.category.domain.Category;
 import com.woowacourse.momo.group.domain.duration.Duration;
-import com.woowacourse.momo.participant.domain.Participant;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
 import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.participant.domain.Participant;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -98,6 +98,10 @@ public class Group {
         belongTo(schedules);
     }
 
+    public boolean isSameHost(Member host) {
+        return Objects.equals(this.hostId, host.getId());
+    }
+
     public void participate(Member member) {
         this.participants.add(new Participant(this, member));
     }
@@ -121,7 +125,6 @@ public class Group {
         private String name;
         private Long hostId;
         private Category category;
-        private List<Participant> participants;
         private Duration duration;
         private LocalDateTime deadline;
         private List<Schedule> schedules;
@@ -148,11 +151,6 @@ public class Group {
 
         public Builder categoryId(long categoryId) {
             this.category = Category.from(categoryId);
-            return this;
-        }
-
-        public Builder participants(List<Participant> participants) {
-            this.participants = participants;
             return this;
         }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -31,8 +31,9 @@ public class GroupService {
     private final GroupRepository groupRepository;
 
     @Transactional
-    public GroupIdResponse create(GroupRequest groupRequest) {
-        Group group = groupRepository.save(GroupRequestAssembler.group(groupRequest));
+    public GroupIdResponse create(Long memberId, GroupRequest groupRequest) {
+        Member host = memberFindService.findMember(memberId);
+        Group group = groupRepository.save(GroupRequestAssembler.group(host, groupRequest));
 
         return GroupResponseAssembler.groupIdResponse(group);
     }
@@ -57,8 +58,10 @@ public class GroupService {
     }
 
     @Transactional
-    public void update(Long groupId, GroupUpdateRequest request) {
+    public void update(Long hostId, Long groupId, GroupUpdateRequest request) {
         Group group = groupFindService.findGroup(groupId);
+        validateHost(group, hostId);
+
         List<Schedule> schedules = GroupRequestAssembler.schedules(request.getSchedules());
 
         group.update(request.getName(), Category.from(request.getCategoryId()),
@@ -67,7 +70,17 @@ public class GroupService {
     }
 
     @Transactional
-    public void delete(Long groupId) {
+    public void delete(Long hostId, Long groupId) {
+        Group group = groupFindService.findGroup(groupId);
+        validateHost(group, hostId);
+
         groupRepository.deleteById(groupId);
+    }
+
+    private void validateHost(Group group, Long hostId) {
+        Member host = memberFindService.findMember(hostId);
+        if (!group.isSameHost(host)) {
+            throw new IllegalArgumentException("해당 모임의 주최자가 아닙니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequest.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 public class GroupRequest {
 
     private String name;
-    private Long hostId;
     private Long categoryId;
     private DurationRequest duration;
     private List<ScheduleRequest> schedules;

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequestAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupRequestAssembler.java
@@ -9,14 +9,15 @@ import lombok.NoArgsConstructor;
 import com.woowacourse.momo.group.domain.duration.Duration;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
+import com.woowacourse.momo.member.domain.Member;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class GroupRequestAssembler {
 
-    public static Group group(GroupRequest request) {
+    public static Group group(Member host, GroupRequest request) {
         return new Group.Builder()
                 .name(request.getName())
-                .hostId(request.getHostId())
+                .hostId(host.getId())
                 .categoryId(request.getCategoryId())
                 .duration(duration(request.getDuration()))
                 .deadline(request.getDeadline())

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
@@ -69,7 +69,7 @@ public class GroupControllerTest {
     void groupCreateTest() throws Exception {
         Long saveMemberId = saveMember();
         String accessToken = accessToken();
-        GroupRequest groupRequest = new GroupRequest("모모의 스터디", saveMemberId, 1L, DURATION_REQUEST,
+        GroupRequest groupRequest = new GroupRequest("모모의 스터디", 1L, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
         mockMvc.perform(post("/api/groups/")
@@ -152,10 +152,10 @@ public class GroupControllerTest {
     }
 
     Long saveGroup(Long hostId) {
-        GroupRequest groupRequest = new GroupRequest("모모의 스터디", hostId, 1L, DURATION_REQUEST,
+        GroupRequest groupRequest = new GroupRequest("모모의 스터디", 1L, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
-        return groupService.create(groupRequest).getGroupId();
+        return groupService.create(hostId, groupRequest).getGroupId();
     }
 
     String accessToken() {

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -67,10 +67,10 @@ class GroupServiceTest {
     @DisplayName("모임을 생성한다")
     @Test
     void create() {
-        GroupRequest request = new GroupRequest("모모의 스터디", savedMember.getId(), Category.STUDY.getId(),
+        GroupRequest request = new GroupRequest("모모의 스터디", Category.STUDY.getId(),
                 DURATION_REQUEST, SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
-        groupService.create(request);
+        groupService.create(savedMember.getId(), request);
 
         assertThat(groupRepository.findAll()).hasSize(1);
     }
@@ -79,10 +79,10 @@ class GroupServiceTest {
     @Test
     void createWithInvalidCategoryId() {
         Long categoryId = 0L;
-        GroupRequest request = new GroupRequest("모모의 스터디", savedMember.getId(), categoryId, DURATION_REQUEST,
+        GroupRequest request = new GroupRequest("모모의 스터디", categoryId, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, LocalDateTime.now(), "", "");
 
-        assertThatThrownBy(() -> groupService.create(request))
+        assertThatThrownBy(() -> groupService.create(savedMember.getId(), request))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("카테고리를 찾을 수 없습니다.");
     }
@@ -125,7 +125,7 @@ class GroupServiceTest {
     @Test
     void delete() {
         long groupId = saveGroup().getId();
-        groupService.delete(groupId);
+        groupService.delete(savedMember.getId(), groupId);
 
         assertThatThrownBy(() -> groupService.findById(groupId))
                 .isInstanceOf(NotFoundGroupException.class);

--- a/backend/src/test/java/com/woowacourse/momo/participant/acceptance/ParticipantAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/acceptance/ParticipantAcceptanceTest.java
@@ -65,8 +65,9 @@ public class ParticipantAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 비회원은_모임에_참여할_수_없다() {
+        long groupId = 생성한_모임_아이디();
         탈퇴한다(token);
-        ExtractableResponse<Response> response = 모임에_참여한다(token, 생성한_모임_아이디());
+        ExtractableResponse<Response> response = 모임에_참여한다(token, groupId);
 
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value()),


### PR DESCRIPTION
close #92 

- CORS 설정을 `AuthConfiguration`로부터 `GlobalWebConfiguration` 클래스로 분리
- `AuthInterceptor`에서 처리되던 RestDocs 경로 패턴 로직을 `AuthConfiguration`의 interceptor 경로 패턴 적용으로 해결