### PR TITLE
[FE] lottie-react 버젼 충돌 이슈 해결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,9 +25,9 @@
     "@emotion/styled": "^11.9.3",
     "axios": "^0.27.2",
     "emotion-reset": "^3.0.1",
+    "lottie-react": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-lottie": "^1.2.3",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
     "recoil": "^0.7.4"
@@ -52,7 +52,6 @@
     "@types/node": "^18.0.0",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^18.0.5",
-    "@types/react-lottie": "^1.2.6",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "babel-loader": "^8.2.5",

--- a/frontend/src/components/Animation/NotFoundPageAnimation.tsx
+++ b/frontend/src/components/Animation/NotFoundPageAnimation.tsx
@@ -1,15 +1,13 @@
-import Lottie from 'react-lottie';
+import Lottie from 'lottie-react';
 
-import * as animationData from 'assets/not_found.json';
+import notFound from 'assets/not_found.json';
 
-const defaultOptions = {
-  loop: true,
-  autoplay: true,
-  animationData: animationData,
+const style = {
+  height: 300,
 };
 
 function NotFoundPage() {
-  return <Lottie options={defaultOptions} height={400} width={400} />;
+  return <Lottie animationData={notFound} style={style} />;
 }
 
 export default NotFoundPage;

--- a/frontend/src/components/Animation/SpinnerAnimation.tsx
+++ b/frontend/src/components/Animation/SpinnerAnimation.tsx
@@ -1,15 +1,13 @@
-import Lottie from 'react-lottie';
+import Lottie from 'lottie-react';
 
-import * as animationData from 'assets/spinner.json';
+import spinner from 'assets/spinner.json';
 
-const defaultOptions = {
-  loop: true,
-  autoplay: true,
-  animationData: animationData,
+const style = {
+  height: 300,
 };
 
 function Spinner() {
-  return <Lottie options={defaultOptions} height={400} width={400} />;
+  return <Lottie animationData={spinner} style={style} />;
 }
 
 export default Spinner;


### PR DESCRIPTION
## Issue

- #127 

## Description (optional)

**lottie for react 라이브러리 교체**

- 기존에 사용되던 `react-lottie` 라이브러리 지원 종료
- 리액트 18을 지원하는 `lottie-react` 라이브러리로 교체 필요

closed #127 