### PR TITLE
[BE] 모임 전체 조회 반환값에 현재 참여자 수 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -135,9 +135,13 @@ public class Group {
     }
 
     private void validateOverCapacity() {
-        if (this.capacity <= participants.size()) {
+        if (this.capacity <= getParticipantsSize()) {
             throw new IllegalArgumentException("정원이 가득 찼습니다.");
         }
+    }
+
+    public int getParticipantsSize() {
+        return participants.size();
     }
 
     private void belongTo(List<Schedule> schedules) {

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -135,13 +135,9 @@ public class Group {
     }
 
     private void validateOverCapacity() {
-        if (this.capacity <= getParticipantsSize()) {
+        if (this.capacity <= participants.size()) {
             throw new IllegalArgumentException("정원이 가득 찼습니다.");
         }
-    }
-
-    public int getParticipantsSize() {
-        return participants.size();
     }
 
     private void belongTo(List<Schedule> schedules) {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupResponseAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupResponseAssembler.java
@@ -24,7 +24,7 @@ public class GroupResponseAssembler {
     public static GroupSummaryResponse groupSummaryResponse(Group group) {
         return new GroupSummaryResponse(group.getId(), group.getName(),
                 MemberResponseAssembler.memberResponse(group.getHost()), group.getCategory().getId(),
-                group.getCapacity(), group.getDeadline());
+                group.getCapacity(), group.getParticipantsSize(), group.getDeadline());
     }
 
     public static GroupIdResponse groupIdResponse(Group group) {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupResponseAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupResponseAssembler.java
@@ -24,7 +24,7 @@ public class GroupResponseAssembler {
     public static GroupSummaryResponse groupSummaryResponse(Group group) {
         return new GroupSummaryResponse(group.getId(), group.getName(),
                 MemberResponseAssembler.memberResponse(group.getHost()), group.getCategory().getId(),
-                group.getCapacity(), group.getParticipantsSize(), group.getDeadline());
+                group.getCapacity(), group.getParticipants().size(), group.getDeadline());
     }
 
     public static GroupIdResponse groupIdResponse(Group group) {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupSummaryResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupSummaryResponse.java
@@ -18,6 +18,7 @@ public class GroupSummaryResponse {
     private MemberResponse host;
     private Long categoryId;
     private int capacity;
+    private int numOfParticipant;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm", timezone = "Asia/Seoul")
     private LocalDateTime deadline;
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupFindAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupFindAcceptanceTest.java
@@ -25,9 +25,11 @@ import org.springframework.http.HttpStatus;
 import io.restassured.response.ValidatableResponse;
 
 import com.woowacourse.momo.acceptance.AcceptanceTest;
+import com.woowacourse.momo.acceptance.participant.ParticipantRestHandler;
 import com.woowacourse.momo.fixture.GroupFixture;
 import com.woowacourse.momo.fixture.MemberFixture;
 import com.woowacourse.momo.group.service.dto.response.ScheduleResponse;
+import com.woowacourse.momo.member.service.dto.response.MemberResponse;
 
 class GroupFindAcceptanceTest extends AcceptanceTest {
 
@@ -130,11 +132,17 @@ class GroupFindAcceptanceTest extends AcceptanceTest {
             GroupFixture group = groups.get(i);
             String deadline = group.getDeadline().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
 
+            int numOfParticipant = ParticipantRestHandler.참여목록을_조회한다(groupIds.get(group))
+                    .extract()
+                    .as(MemberResponse[].class)
+                    .length;
+
             String index = String.format("[%d]", i);
             response.body(index + ".id", is(groupIds.get(group).intValue()))
                     .body(index + ".name", is(group.getName()))
                     .body(index + ".categoryId", is(group.getCategoryId().intValue()))
                     .body(index + ".capacity", is(group.getCapacity()))
+                    .body(index + ".numOfParticipant", is(numOfParticipant))
                     .body(index + ".deadline", is(deadline))
                     .body(index + ".host.id", is(1))
                     .body(index + ".host.name", is(HOST.getName()));


### PR DESCRIPTION
- Issue #137

#  🌟 구현할 기능
모임 전체 조회 반환값에 현재 참여자 수 추가

# 🛠 상세 작업 
- API 스펙에 따라 전체 모임 전체 조회시 반환 값에 참여자 수 추가

# ⏰ 예상 소요 시간
20분

- close #137
