### PR TITLE
[BE] RestDocs 빌드 시 파일생성 문제 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -69,4 +69,9 @@ bootJar {
 		from "${asciidoctor.outputDir}"
 		into 'src/main/resources/static/docs'
 	}
+
+	copy {
+		from file("src/main/resources/static")
+		into file("build/resources/main/static")
+	}
 }


### PR DESCRIPTION
build 폴더에 html 파일을 넣어주는 방식으로 해결하였습니다 🥺

```
copy {
  from file("src/main/resources/static")
  into file("build/resources/main/static")
}
```