### PR TITLE
[BE] 모임 수정 로직 추가 및 회원정보 조회 API 반환값 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -96,9 +96,8 @@ public class Group {
         belongTo(schedules);
     }
 
-    public void update(String name, Category category, int capacity, Duration duration, LocalDateTime deadline,
+    public void update(Category category, int capacity, Duration duration, LocalDateTime deadline,
                        List<Schedule> schedules, String location, String description) {
-        this.name = name;
         this.category = category;
         this.capacity = capacity;
         this.duration = duration;

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -61,7 +61,7 @@ public class GroupService {
         List<Group> groupsOfPage = groups.getContent();
         List<GroupSummaryResponse> summaries = GroupResponseAssembler.groupSummaryResponses(groupsOfPage);
 
-        return GroupResponseAssembler.groupPageResponse(summaries, groups.hasNext());
+        return GroupResponseAssembler.groupPageResponse(summaries, groups.hasNext(), pageNumber);
     }
 
     @Transactional

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -72,7 +72,7 @@ public class GroupService {
 
         List<Schedule> schedules = GroupRequestAssembler.schedules(request.getSchedules());
 
-        group.update(request.getName(), Category.from(request.getCategoryId()), request.getCapacity(),
+        group.update(Category.from(request.getCategoryId()), request.getCapacity(),
                 GroupRequestAssembler.duration(request.getDuration()), request.getDeadline(), schedules,
                 request.getLocation(), request.getDescription());
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupUpdateRequest.java
@@ -15,7 +15,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GroupUpdateRequest {
 
-    private String name;
     private Long categoryId;
     private Integer capacity;
     private DurationRequest duration;

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupPageResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupPageResponse.java
@@ -10,5 +10,6 @@ import lombok.Getter;
 public class GroupPageResponse {
 
     boolean hasNextPage;
+    int pageNumber;
     List<GroupSummaryResponse> groups;
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupResponseAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/response/GroupResponseAssembler.java
@@ -34,8 +34,9 @@ public class GroupResponseAssembler {
                 group.getDeadline());
     }
 
-    public static GroupPageResponse groupPageResponse(List<GroupSummaryResponse> groupSummaryResponses, boolean hasNextPage) {
-        return new GroupPageResponse(hasNextPage, groupSummaryResponses);
+    public static GroupPageResponse groupPageResponse(List<GroupSummaryResponse> groupSummaryResponses,
+                                                      boolean hasNextPage, int pageNumber) {
+        return new GroupPageResponse(hasNextPage, pageNumber, groupSummaryResponses);
     }
 
     public static GroupIdResponse groupIdResponse(Group group) {

--- a/backend/src/main/java/com/woowacourse/momo/member/service/dto/response/MemberResponseAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/dto/response/MemberResponseAssembler.java
@@ -12,7 +12,7 @@ import com.woowacourse.momo.member.domain.Member;
 public class MemberResponseAssembler {
 
     public static MyInfoResponse myInfoResponse(Member member) {
-        return new MyInfoResponse(member.getUserId(), member.getName());
+        return new MyInfoResponse(member.getId(), member.getUserId(), member.getName());
     }
 
     public static MemberResponse memberResponse(Member member) {

--- a/backend/src/main/java/com/woowacourse/momo/member/service/dto/response/MyInfoResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/dto/response/MyInfoResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MyInfoResponse {
 
+    private Long id;
     private String userId;
     private String name;
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupRestHandler.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupRestHandler.java
@@ -92,17 +92,17 @@ public class GroupRestHandler extends RestHandler {
     }
 
     public static GroupUpdateRequest groupUpdateRequest(GroupFixture group) {
-        return groupUpdateRequest(group.getName(), group.getCategoryId(), group.getCapacity(), group.getDuration(),
-                group.getSchedules(), group.getDeadline(), group.getLocation(), group.getDescription());
+        return groupUpdateRequest(group.getCategoryId(), group.getCapacity(), group.getDuration(), group.getSchedules(),
+                group.getDeadline(), group.getLocation(), group.getDescription());
     }
 
-    public static GroupUpdateRequest groupUpdateRequest(String name, Long categoryId, Integer capacity,
-                                                        Duration duration, List<Schedule> schedules,
-                                                        LocalDateTime deadline, String location, String description) {
+    public static GroupUpdateRequest groupUpdateRequest(Long categoryId, Integer capacity, Duration duration,
+                                                        List<Schedule> schedules, LocalDateTime deadline,
+                                                        String location, String description) {
         DurationRequest durationRequest = durationRequest(duration);
         List<ScheduleRequest> scheduleRequests = scheduleRequests(schedules);
-        return new GroupUpdateRequest(name, categoryId, capacity, durationRequest, scheduleRequests, deadline,
-                location, description);
+        return new GroupUpdateRequest(categoryId, capacity, durationRequest, scheduleRequests, deadline, location,
+                description);
     }
 
     private static DurationRequest durationRequest(Duration duration) {

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
@@ -54,7 +54,6 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
                     String deadline = updatedGroup.getDeadline()
                             .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
                     response
-                            .body("name", is(updatedGroup.getName()))
                             .body("host.id", is(1))
                             .body("host.name", is(HOST.getName()))
                             .body("categoryId", is(updatedGroup.getCategoryId().intValue()))

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
@@ -97,7 +97,7 @@ class GroupControllerTest {
         Long saveMemberId = saveMember();
         String accessToken = accessToken();
         Long savedGroupId = saveGroup("모모의 스터디", saveMemberId);
-        GroupUpdateRequest groupRequest = new GroupUpdateRequest("변경된 모모의 스터디", 1L, 15,
+        GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 15,
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         mockMvc.perform(put("/api/groups/" + savedGroupId)

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -138,7 +138,7 @@ class GroupServiceTest {
         savedGroup.participate(savedMember2);
         long groupId = savedGroup.getId();
 
-        GroupUpdateRequest groupRequest = new GroupUpdateRequest("변경된 모모의 스터디", 1L, 2,
+        GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 2,
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         assertThatThrownBy(() -> groupService.update(savedMember.getId(), groupId, groupRequest))

--- a/backend/src/test/java/com/woowacourse/momo/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.momo.member.controller;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -62,6 +63,7 @@ public class MemberControllerTest {
     void find() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/members")
                         .header("authorization", "bearer " + accessToken))
+                .andExpect(jsonPath("id", notNullValue()))
                 .andExpect(jsonPath("userId", is(ID)))
                 .andDo(
                         document("memberfind",

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -41,11 +41,9 @@ class MemberServiceTest {
         MyInfoResponse response = memberService.findById(memberId);
 
         assertAll(
-                () -> assertThat(memberId).isEqualTo(response.getId()),
-                () -> assertThat(response).usingRecursiveComparison()
-                        .ignoringFields("id")
-                        .ignoringFields("password")
-                        .isEqualTo(request)
+                () -> assertThat(response.getId()).isEqualTo(memberId),
+                () -> assertThat(response.getUserId()).isEqualTo(request.getUserId()),
+                () -> assertThat(response.getName()).isEqualTo(request.getName())
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.momo.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,9 +40,13 @@ class MemberServiceTest {
 
         MyInfoResponse response = memberService.findById(memberId);
 
-        assertThat(response).usingRecursiveComparison()
-                .ignoringFields("password")
-                .isEqualTo(request);
+        assertAll(
+                () -> assertThat(memberId).isEqualTo(response.getId()),
+                () -> assertThat(response).usingRecursiveComparison()
+                        .ignoringFields("id")
+                        .ignoringFields("password")
+                        .isEqualTo(request)
+        );
     }
 
     @DisplayName("회원 비밀번호를 수정한다")
@@ -75,7 +80,6 @@ class MemberServiceTest {
     @DisplayName("회원 정보를 삭제한다")
     @Test
     void delete() {
-
         Long memberId = createMember();
 
         memberService.deleteById(memberId);


### PR DESCRIPTION
# 🌟 구현한 기능
### 모임 수정 로직 추가
- [x] 모임의 이름 수정 불가

### 회원정보 조회 API 반환값 수정
- [x] 회원정보 조회 시 사용자 식별자(DB 아이디) 추가

close #120 