### PR TITLE
[FE] 해당 모임에 대한 사용자의 역할 판단 로직 추가

### DIFF
--- a/frontend/src/apis/request/user.ts
+++ b/frontend/src/apis/request/user.ts
@@ -1,13 +1,13 @@
 import axios from 'apis/axios';
 import { ERROR_MESSAGE } from 'constants/message';
 import { API_PATH } from 'constants/path';
-import { UserInfo } from 'types/user';
+import { UserProfile } from 'types/user';
 
 const getUserInfo = () => {
   const accessToken = sessionStorage.getItem('accessToken') ?? '';
 
   return axios
-    .get<UserInfo>(API_PATH.MEMBERS, {
+    .get<UserProfile>(API_PATH.MEMBERS, {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },

--- a/frontend/src/components/Detail/SideBar/Info/ControlButton/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Info/ControlButton/index.tsx
@@ -18,7 +18,7 @@ interface ControlButtonProps {
 }
 
 function ControlButton({ id }: ControlButtonProps) {
-  const isLogin = useRecoilValue(loginState);
+  const { isLogin } = useRecoilValue(loginState);
   const setModalState = useSetRecoilState(modalState);
   const navigate = useNavigate();
 

--- a/frontend/src/components/Detail/SideBar/Info/ControlButton/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Info/ControlButton/index.tsx
@@ -13,12 +13,8 @@ import { GroupDetailData } from 'types/data';
 
 import * as S from './index.styled';
 
-interface ControlButtonProps {
-  id: GroupDetailData['id'];
-}
-
-function ControlButton({ id }: ControlButtonProps) {
-  const { isLogin } = useRecoilValue(loginState);
+function ControlButton({ id, host }: Pick<GroupDetailData, 'id' | 'host'>) {
+  const { isLogin, user } = useRecoilValue(loginState);
   const setModalState = useSetRecoilState(modalState);
   const navigate = useNavigate();
 
@@ -78,11 +74,9 @@ function ControlButton({ id }: ControlButtonProps) {
       });
   };
 
-  // TODO: API가 나온 후 호스트인지 아닌지 여부 판단
-  const isHost = false;
   const isJoined = false;
 
-  if (isHost) {
+  if (user?.id === host.id) {
     return (
       <S.HostButtonContainer>
         <S.EarlyClosedButton type="button" onClick={closeGroup}>

--- a/frontend/src/components/Detail/SideBar/Info/ControlButton/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Info/ControlButton/index.tsx
@@ -9,11 +9,15 @@ import {
 } from 'apis/request/group';
 import { ERROR_MESSAGE, GUIDE_MESSAGE } from 'constants/message';
 import { loginState, modalState } from 'store/states';
-import { GroupDetailData } from 'types/data';
+import { GroupDetailData, GroupParticipants } from 'types/data';
 
 import * as S from './index.styled';
 
-function ControlButton({ id, host }: Pick<GroupDetailData, 'id' | 'host'>) {
+type ControlButtonProps = Pick<GroupDetailData, 'id' | 'host'> & {
+  participants: GroupParticipants;
+};
+
+function ControlButton({ id, host, participants }: ControlButtonProps) {
   const { isLogin, user } = useRecoilValue(loginState);
   const setModalState = useSetRecoilState(modalState);
   const navigate = useNavigate();
@@ -74,7 +78,9 @@ function ControlButton({ id, host }: Pick<GroupDetailData, 'id' | 'host'>) {
       });
   };
 
-  const isJoined = false;
+  const isJoined = participants.some(
+    participant => participant.id === user?.id,
+  );
 
   if (user?.id === host.id) {
     return (

--- a/frontend/src/components/Detail/SideBar/Info/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Info/index.tsx
@@ -2,7 +2,7 @@ import { ReactComponent as ClockSVG } from 'assets/clock.svg';
 import { ReactComponent as LocationSVG } from 'assets/location.svg';
 import CategorySVG from 'components/svg/Category';
 import PersonSVG from 'components/svg/Person';
-import { CategoryType, GroupDetailData } from 'types/data';
+import { CategoryType, GroupDetailData, GroupParticipants } from 'types/data';
 import { parsedDurationDate } from 'utils/date';
 
 import ControlButton from './ControlButton';
@@ -17,9 +17,17 @@ type InfoProps = Pick<
   'id' | 'host' | 'duration' | 'location'
 > & {
   categoryName: CategoryType['name'];
+  participants: GroupParticipants;
 };
 
-function Info({ id, host, duration, categoryName, location }: InfoProps) {
+function Info({
+  id,
+  host,
+  duration,
+  categoryName,
+  location,
+  participants,
+}: InfoProps) {
   return (
     <S.Container>
       <S.Wrapper>
@@ -38,7 +46,7 @@ function Info({ id, host, duration, categoryName, location }: InfoProps) {
         <PersonSVG width={svgSize} />
         <S.Text>{host.name}</S.Text>
       </S.Wrapper>
-      <ControlButton id={id} host={host} />
+      <ControlButton id={id} host={host} participants={participants} />
     </S.Container>
   );
 }

--- a/frontend/src/components/Detail/SideBar/Info/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Info/index.tsx
@@ -14,12 +14,12 @@ const svgSize = 32;
 
 type InfoProps = Pick<
   GroupDetailData,
-  'id' | 'name' | 'duration' | 'location'
+  'id' | 'host' | 'duration' | 'location'
 > & {
   categoryName: CategoryType['name'];
 };
 
-function Info({ id, name, duration, categoryName, location }: InfoProps) {
+function Info({ id, host, duration, categoryName, location }: InfoProps) {
   return (
     <S.Container>
       <S.Wrapper>
@@ -36,9 +36,9 @@ function Info({ id, name, duration, categoryName, location }: InfoProps) {
       </S.Wrapper>
       <S.Wrapper>
         <PersonSVG width={svgSize} />
-        <S.Text>{name}</S.Text>
+        <S.Text>{host.name}</S.Text>
       </S.Wrapper>
-      <ControlButton id={id} />
+      <ControlButton id={id} host={host} />
     </S.Container>
   );
 }

--- a/frontend/src/components/Detail/SideBar/Participants/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Participants/index.tsx
@@ -4,19 +4,15 @@ import { GroupDetailData, GroupParticipants } from 'types/data';
 
 import * as S from './index.styled';
 
-interface ParticipantsProps {
-  id: GroupDetailData['id'];
-  hostName: GroupDetailData['host']['name'];
-  capacity: GroupDetailData['capacity'];
+type ParticipantsProps = Pick<GroupDetailData, 'host' | 'capacity'> & {
   participants: GroupParticipants;
-}
+};
 
-function Participants({
-  id,
-  hostName,
-  capacity,
-  participants,
-}: ParticipantsProps) {
+function Participants({ host, capacity, participants }: ParticipantsProps) {
+  const participantsWithoutHost = participants.filter(
+    participant => participant.id !== host.id,
+  );
+
   return (
     <S.Container>
       <S.Header>참여자 목록</S.Header>
@@ -26,9 +22,9 @@ function Participants({
       <S.Box>
         <S.Wrapper>
           <CrownSVG width={32} />
-          <S.HostText>{hostName}</S.HostText>
+          <S.HostText>{host.name}</S.HostText>
         </S.Wrapper>
-        {participants?.map(participant => (
+        {participantsWithoutHost.map(participant => (
           <S.Wrapper key={participant.id}>
             <PersonSVG width={32} />
             <S.Text>{participant.name}</S.Text>

--- a/frontend/src/components/Detail/SideBar/Participants/index.tsx
+++ b/frontend/src/components/Detail/SideBar/Participants/index.tsx
@@ -1,9 +1,5 @@
-import { useQuery } from 'react-query';
-
-import { getGroupParticipants } from 'apis/request/group';
 import { ReactComponent as CrownSVG } from 'assets/crown.svg';
 import PersonSVG from 'components/svg/Person';
-import { QUERY_KEY } from 'constants/key';
 import { GroupDetailData, GroupParticipants } from 'types/data';
 
 import * as S from './index.styled';
@@ -12,15 +8,15 @@ interface ParticipantsProps {
   id: GroupDetailData['id'];
   hostName: GroupDetailData['host']['name'];
   capacity: GroupDetailData['capacity'];
+  participants: GroupParticipants;
 }
 
-function Participants({ id, hostName, capacity }: ParticipantsProps) {
-  const { data: participants } = useQuery<GroupParticipants>(
-    `${QUERY_KEY.GROUP_PARTICIPANTS}/${id}`,
-    () => getGroupParticipants(id),
-    { staleTime: Infinity },
-  );
-
+function Participants({
+  id,
+  hostName,
+  capacity,
+  participants,
+}: ParticipantsProps) {
   return (
     <S.Container>
       <S.Header>참여자 목록</S.Header>

--- a/frontend/src/components/Detail/SideBar/index.tsx
+++ b/frontend/src/components/Detail/SideBar/index.tsx
@@ -43,8 +43,7 @@ function DetailSideBar({
       />
       <Calendar schedules={schedules} />
       <Participants
-        id={id}
-        hostName={host.name}
+        host={host}
         capacity={capacity}
         participants={participants}
       />

--- a/frontend/src/components/Detail/SideBar/index.tsx
+++ b/frontend/src/components/Detail/SideBar/index.tsx
@@ -7,7 +7,7 @@ import Participants from './Participants';
 
 function DetailSideBar({
   id,
-  name,
+  host,
   capacity,
   duration,
   schedules,
@@ -15,7 +15,7 @@ function DetailSideBar({
   categoryName,
 }: Pick<
   GroupDetailData,
-  'id' | 'name' | 'capacity' | 'duration' | 'schedules' | 'location'
+  'id' | 'host' | 'capacity' | 'duration' | 'schedules' | 'location'
 > & {
   categoryName: CategoryType['name'];
 }) {
@@ -23,13 +23,13 @@ function DetailSideBar({
     <S.Container>
       <Info
         id={id}
-        name={name}
+        host={host}
         duration={duration}
         location={location}
         categoryName={categoryName}
       />
       <Calendar schedules={schedules} />
-      <Participants id={id} hostName={name} capacity={capacity} />
+      <Participants id={id} hostName={host.name} capacity={capacity} />
     </S.Container>
   );
 }

--- a/frontend/src/components/Detail/SideBar/index.tsx
+++ b/frontend/src/components/Detail/SideBar/index.tsx
@@ -1,4 +1,8 @@
-import { CategoryType, GroupDetailData } from 'types/data';
+import { useQuery } from 'react-query';
+
+import { getGroupParticipants } from 'apis/request/group';
+import { QUERY_KEY } from 'constants/key';
+import { CategoryType, GroupDetailData, GroupParticipants } from 'types/data';
 
 import Calendar from './Calendar';
 import * as S from './index.styled';
@@ -19,6 +23,14 @@ function DetailSideBar({
 > & {
   categoryName: CategoryType['name'];
 }) {
+  const { data: participants } = useQuery<GroupParticipants>(
+    `${QUERY_KEY.GROUP_PARTICIPANTS}/${id}`,
+    () => getGroupParticipants(id),
+    { staleTime: Infinity },
+  );
+
+  if (!participants) return <></>;
+
   return (
     <S.Container>
       <Info
@@ -27,9 +39,15 @@ function DetailSideBar({
         duration={duration}
         location={location}
         categoryName={categoryName}
+        participants={participants}
       />
       <Calendar schedules={schedules} />
-      <Participants id={id} hostName={host.name} capacity={capacity} />
+      <Participants
+        id={id}
+        hostName={host.name}
+        capacity={capacity}
+        participants={participants}
+      />
     </S.Container>
   );
 }

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
+import { getUserInfo } from 'apis/request/user';
 import { ReactComponent as LogoSVG } from 'assets/logo.svg';
 import NavLink from 'components/@shared/NavLink';
 import { GUIDE_MESSAGE } from 'constants/message';
@@ -14,13 +15,15 @@ import * as S from './index.styled';
 function Header() {
   const setModalState = useSetRecoilState(modalState);
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
-  const [isLogin, setIsLogin] = useRecoilState(loginState);
+  const [{ isLogin }, setLoginInfo] = useRecoilState(loginState);
 
   useEffect(() => {
     if (accessToken) {
-      setIsLogin(true);
+      getUserInfo().then(userInfo => {
+        setLoginInfo({ isLogin: true, user: userInfo });
+      });
     }
-  }, [accessToken, setIsLogin]);
+  }, [accessToken, setLoginInfo]);
 
   const changeModalState = (modalState: ModalStateType) => () => {
     setModalState(modalState);
@@ -29,7 +32,7 @@ function Header() {
   const logout = () => {
     if (!window.confirm(GUIDE_MESSAGE.AUTH.CONFIRM_LOGOUT)) return;
 
-    setIsLogin(false);
+    setLoginInfo({ isLogin: false });
     setAccessToken('');
   };
 

--- a/frontend/src/components/Login/index.tsx
+++ b/frontend/src/components/Login/index.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { requestLogin } from 'apis/request/auth';
+import { getUserInfo } from 'apis/request/user';
 import Modal from 'components/Modal';
 import { GUIDE_MESSAGE } from 'constants/message';
 import { accessTokenState, loginState, modalState } from 'store/states';
@@ -13,7 +14,7 @@ import * as S from './index.styled';
 function Login() {
   const [modalFlag, setModalFlag] = useRecoilState(modalState);
   const setAccessToken = useSetRecoilState(accessTokenState);
-  const setIsLogin = useSetRecoilState(loginState);
+  const setLoginInfo = useSetRecoilState(loginState);
   const userIdRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);
 
@@ -33,8 +34,11 @@ function Login() {
       .then(accessToken => {
         alert(GUIDE_MESSAGE.AUTH.LOGIN_SUCCESS);
 
+        getUserInfo().then(userInfo => {
+          setLoginInfo({ isLogin: true, user: userInfo });
+        });
+
         setAccessToken(accessToken);
-        setIsLogin(true);
         setOffModal();
       })
       .catch(({ message }) => {

--- a/frontend/src/pages/Detail/index.tsx
+++ b/frontend/src/pages/Detail/index.tsx
@@ -26,7 +26,7 @@ function Detail() {
         <>
           <DetailSideBar
             id={Number(id)}
-            name={data.host.name}
+            host={data.host}
             capacity={data.capacity}
             duration={data.duration}
             schedules={data.schedules}

--- a/frontend/src/pages/MyInfo/index.tsx
+++ b/frontend/src/pages/MyInfo/index.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import { useQuery } from 'react-query';
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import {
-  getUserInfo,
   requestChangeName,
   requestChangePassword,
   requestWithdrawal,
@@ -13,7 +11,6 @@ import {
 import { ReactComponent as CompleteSVG } from 'assets/complete.svg';
 import { ReactComponent as PencilSVG } from 'assets/pencil.svg';
 import cover from 'assets/userInfo_cover.jpg';
-import { QUERY_KEY } from 'constants/key';
 import { ERROR_MESSAGE, GUIDE_MESSAGE } from 'constants/message';
 import useInput from 'hooks/useInput';
 import { accessTokenState, loginState } from 'store/states';
@@ -21,23 +18,17 @@ import { accessTokenState, loginState } from 'store/states';
 import * as S from './index.styled';
 
 function MemberInfo() {
-  const { data } = useQuery(QUERY_KEY.USER_INFO, getUserInfo, {
-    suspense: true,
-  });
-  const { value: name, setValue: setName, dangerouslySetValue } = useInput('');
+  const setAccessToken = useSetRecoilState(accessTokenState);
+  const [{ user }, setLoginInfo] = useRecoilState(loginState);
+
+  const { value: name, setValue: setName } = useInput(user?.name || '');
   const { value: password, setValue: setPassword } = useInput('');
   const { value: confirmPassword, setValue: setConfirmPassword } = useInput('');
+
   const [isEditableName, setIsEditableName] = useState(false);
   const [isEditablePassword, setIsEditablePassword] = useState(false);
-  const setAccessToken = useSetRecoilState(accessTokenState);
-  const setIsLogin = useSetRecoilState(loginState);
+
   const navigate = useNavigate();
-
-  useEffect(() => {
-    if (typeof data === 'undefined') return;
-
-    dangerouslySetValue(data.name);
-  }, [data, dangerouslySetValue]);
 
   const changeNameEditable = () => {
     setIsEditableName(true);
@@ -80,7 +71,7 @@ function MemberInfo() {
 
     requestWithdrawal()
       .then(() => {
-        setIsLogin(false);
+        setLoginInfo({ isLogin: false });
         setAccessToken('');
         alert(GUIDE_MESSAGE.MEMBER.SUCCESS_WITHDRAWAL_REQUEST);
         navigate('/');
@@ -98,7 +89,7 @@ function MemberInfo() {
         <S.InputContainer>
           <S.Label>
             아이디
-            <S.Input type="userId" value={data?.userId} disabled />
+            <S.Input type="userId" value={user?.userId} disabled />
           </S.Label>
           <S.Label>
             닉네임

--- a/frontend/src/store/states.ts
+++ b/frontend/src/store/states.ts
@@ -2,6 +2,7 @@ import { atom, DefaultValue, selector } from 'recoil';
 
 import { ModalStateType } from 'types/condition';
 import { CategoryType } from 'types/data';
+import { LoginState } from 'types/user';
 
 const categoryState = atom<CategoryType[]>({
   key: 'categoryState',
@@ -13,9 +14,9 @@ const modalState = atom<ModalStateType>({
   default: 'off',
 });
 
-const loginState = atom<boolean>({
+const loginState = atom<LoginState>({
   key: 'loginState',
-  default: false,
+  default: { isLogin: false },
 });
 
 const accessTokenState = selector<string>({

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -8,4 +8,7 @@ export interface UserProfile extends Omit<User, 'password'> {
   id: number;
 }
 
-export type UserInfo = Omit<User, 'password'>;
+export interface LoginState {
+  isLogin: boolean;
+  user?: UserProfile;
+}


### PR DESCRIPTION
## Issue

- #182 

## Description (optional)

- 로그인 시 또는 access token이 있을 때 사용자 정보를 요청하여 리코일에 저장
  - 내 정보 페이지에서 이를 사용하도록 변경
- 해당 모임에 대해 현재 로그인한 사용자의 역할(호스트인지, 현재 참여하고 있는지)을 판단하는 로직 추가
- 모임 상세 페이지의 참여자 목록에서 호스트를 제외한 사람들만 일반 참여자로 보여주도록 변경

closed #182 