### PR TITLE
[FE] 모임 생성 시 상세 일정 입력 기능 추가

### DIFF
--- a/frontend/src/apis/request/group.ts
+++ b/frontend/src/apis/request/group.ts
@@ -15,6 +15,7 @@ const requestCreateGroup = async ({
   capacity,
   startDate,
   endDate,
+  schedules,
   deadline,
   location,
   description,
@@ -27,19 +28,7 @@ const requestCreateGroup = async ({
       start: startDate,
       end: endDate,
     },
-    // TODO: 달력 입력에 따라 스케줄 시간 바꾸기
-    schedules: [
-      {
-        date: startDate,
-        startTime: '10:00',
-        endTime: '18:00',
-      },
-      {
-        date: endDate,
-        startTime: '10:00',
-        endTime: '18:00',
-      },
-    ],
+    schedules,
     deadline,
     location,
     description,

--- a/frontend/src/components/@shared/Calendar/index.styled.ts
+++ b/frontend/src/components/@shared/Calendar/index.styled.ts
@@ -1,6 +1,17 @@
+import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
 type Size = 'medium' | 'large';
+
+const calendarAnimation = keyframes`
+  from {
+    transform: translate(0, 10px);
+  }
+
+  to {
+    transform: translate(0, 0);
+  }
+`;
 
 const Container = styled.div`
   display: flex;
@@ -52,6 +63,8 @@ const Content = styled.div`
   place-items: center;
   text-align: center;
   gap: 1rem;
+
+  animation: ${calendarAnimation} 0.2s;
 `;
 
 const DayColor = styled.div`
@@ -66,6 +79,10 @@ const DayColor = styled.div`
 
 const PrevNextDate = styled.div`
   color: ${({ theme: { colors } }) => colors.gray001};
+
+  &.disabled {
+    color: ${({ theme: { colors } }) => colors.gray003};
+  }
 `;
 
 const Date = styled(DayColor)`
@@ -81,13 +98,20 @@ const Date = styled(DayColor)`
 
   cursor: pointer;
 
-  &:hover {
+  &:hover,
+  &.selected {
     background: ${({ theme: { colors } }) => colors.yellow002};
   }
 
   &.today {
     background: ${({ theme: { colors } }) => colors.red003};
     color: ${({ theme: { colors } }) => colors.white001};
+  }
+
+  &.disabled {
+    color: ${({ theme: { colors } }) => colors.gray005};
+
+    pointer-events: none;
   }
 `;
 

--- a/frontend/src/components/@shared/Calendar/index.tsx
+++ b/frontend/src/components/@shared/Calendar/index.tsx
@@ -29,7 +29,10 @@ interface CalendarProps {
   goToPrevMonth: () => void;
   goToNextMonth: () => void;
   today: Date;
+  duration?: GroupDetailData['duration'];
   schedules: GroupDetailData['schedules'];
+  selectDate?: (year: number, month: number, date: number) => void;
+  selectedDate?: string;
   size: 'medium' | 'large';
 }
 
@@ -39,7 +42,10 @@ function Calendar({
   goToPrevMonth,
   goToNextMonth,
   today,
+  duration,
   schedules,
+  selectDate,
+  selectedDate,
   size,
 }: CalendarProps) {
   const { dates, prevDates, nextDates } = useCalendar(year, month);
@@ -60,6 +66,31 @@ function Calendar({
     );
   };
 
+  const isNotInDuration = (date: number) => {
+    const thisDate = `${year}-${month.toString().padStart(2, '0')}-${date
+      .toString()
+      .padStart(2, '0')}`;
+
+    if (!duration) return false;
+
+    return thisDate < duration.start || thisDate > duration.end;
+  };
+
+  const isSelectedDate = (date: number) => {
+    return (
+      selectedDate ===
+      `${year}-${month.toString().padStart(2, '0')}-${date
+        .toString()
+        .padStart(2, '0')}`
+    );
+  };
+
+  const pickDate = (date: number) => () => {
+    if (!selectDate) return;
+
+    selectDate(year, month, date);
+  };
+
   return (
     <S.Container size={size}>
       <S.Navigator size={size}>
@@ -73,7 +104,7 @@ function Calendar({
           <RightArrow width={30} color={theme.colors.yellow001} />
         </S.RightArrow>
       </S.Navigator>
-      <S.Content>
+      <S.Content key={month}>
         {/* 요일 */}
         {days.map(day => (
           <S.DayColor className={dayClassGenerator(day)} key={day}>
@@ -82,7 +113,13 @@ function Calendar({
         ))}
         {/* 지난달 */}
         {prevDates.map(date => (
-          <S.PrevNextDate key={`${month - 1}-${date}`}>{date}</S.PrevNextDate>
+          <S.PrevNextDate
+            className="disabled"
+            onClick={goToPrevMonth}
+            key={`${month - 1}-${date}`}
+          >
+            {date}
+          </S.PrevNextDate>
         ))}
         {/* 이번달 */}
         {dates.map(date => {
@@ -96,11 +133,17 @@ function Calendar({
             />
           ) : (
             <S.Date
-              className={
-                isToday(date)
-                  ? 'today'
-                  : dayClassGenerator(new Date(year, month - 1, date).getDay())
-              }
+              className={`
+                ${
+                  isNotInDuration(date)
+                    ? 'disabled'
+                    : isSelectedDate(date)
+                    ? 'selected'
+                    : dayClassGenerator(
+                        new Date(year, month - 1, date).getDay(),
+                      )
+                } ${isToday(date) ? 'today' : ''}`}
+              onClick={pickDate(date)}
               key={`${month}-${date}`}
             >
               {date}
@@ -109,7 +152,13 @@ function Calendar({
         })}
         {/* 다음달 */}
         {nextDates.map(date => (
-          <S.PrevNextDate key={`${month + 1}-${date}`}>{date}</S.PrevNextDate>
+          <S.PrevNextDate
+            className="disabled"
+            onClick={goToNextMonth}
+            key={`${month + 1}-${date}`}
+          >
+            {date}
+          </S.PrevNextDate>
         ))}
       </S.Content>
     </S.Container>

--- a/frontend/src/components/Create/Step5/Calendar/index.tsx
+++ b/frontend/src/components/Create/Step5/Calendar/index.tsx
@@ -1,0 +1,39 @@
+import CalendarComponent from 'components/@shared/Calendar';
+import useDate from 'hooks/useDate';
+import { CreateGroupData } from 'types/data';
+
+interface CalendarProps {
+  duration: {
+    start: CreateGroupData['startDate'];
+    end: CreateGroupData['endDate'];
+  };
+  schedules: CreateGroupData['schedules'];
+  selectDate: (year: number, month: number, date: number) => void;
+  selectedDate: string;
+}
+
+function Calendar({
+  duration,
+  schedules,
+  selectDate,
+  selectedDate,
+}: CalendarProps) {
+  const { today, year, month, goToPrevMonth, goToNextMonth } = useDate();
+
+  return (
+    <CalendarComponent
+      year={year}
+      month={month}
+      goToPrevMonth={goToPrevMonth}
+      goToNextMonth={goToNextMonth}
+      today={today}
+      duration={duration}
+      schedules={schedules}
+      selectDate={selectDate}
+      selectedDate={selectedDate}
+      size="large"
+    />
+  );
+}
+
+export default Calendar;

--- a/frontend/src/components/Create/Step5/index.tsx
+++ b/frontend/src/components/Create/Step5/index.tsx
@@ -1,28 +1,73 @@
-import { forwardRef, LegacyRef, memo } from 'react';
+import { forwardRef, LegacyRef, memo, useState } from 'react';
 
-import Calendar from 'components/@shared/Calendar';
-import useDate from 'hooks/useDate';
+import useInput from 'hooks/useInput';
 import { CreateGroupData, ScheduleType } from 'types/data';
 
 import { Container, Heading } from '../@shared/styled';
+import Calendar from './Calendar';
 import * as S from './index.styled';
-
-// TODO: 달력은 나중에 ^^
 
 interface Step5Props {
   useScheduleState: () => {
     schedules: CreateGroupData['schedules'];
-    setSchedules: (schedules: ScheduleType) => void;
+    setSchedules: (schedule: ScheduleType) => void;
+  };
+  duration: {
+    start: CreateGroupData['startDate'];
+    end: CreateGroupData['endDate'];
   };
   pressEnterToNext: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
 
+// TODO: duration이 바뀌면 schedules 날림
+// TODO: schedule 관련 코드 리팩토링
 function Step5(
-  { useScheduleState, pressEnterToNext }: Step5Props,
+  { useScheduleState, duration, pressEnterToNext }: Step5Props,
   ref: LegacyRef<HTMLDivElement>,
 ) {
-  const { schedules } = useScheduleState();
-  const { today, year, month, goToPrevMonth, goToNextMonth } = useDate();
+  const { schedules, setSchedules } = useScheduleState();
+
+  const [selectedDate, setSelectedDate] = useState('');
+  const {
+    value: startTime,
+    setValue: setStartTime,
+    dangerouslySetValue: dangerouslySetStartTime,
+  } = useInput('');
+  const {
+    value: endTime,
+    setValue: setEndTime,
+    dangerouslySetValue: dangerouslySetEndTime,
+  } = useInput('');
+
+  const selectDate = (year: number, month: number, date: number) => {
+    setSelectedDate(
+      `${year}-${month.toString().padStart(2, '0')}-${date
+        .toString()
+        .padStart(2, '0')}`,
+    );
+  };
+
+  const addSchedule = () => {
+    if (startTime >= endTime) {
+      alert('시작 시간은 종료 시간 이전이어야 해요.');
+      return;
+    }
+
+    if (selectedDate < duration.start || selectedDate > duration.end) {
+      alert('잘못된 날짜예요. 다시 선택해주세요 😤');
+    }
+
+    const schedule = {
+      date: selectedDate,
+      startTime,
+      endTime,
+    };
+
+    setSchedules(schedule);
+    setSelectedDate('');
+    dangerouslySetStartTime('');
+    dangerouslySetEndTime('');
+  };
 
   return (
     <Container ref={ref}>
@@ -32,33 +77,33 @@ function Step5(
       <S.Content>
         <S.Left>
           <Calendar
-            year={year}
-            month={month}
-            goToPrevMonth={goToPrevMonth}
-            goToNextMonth={goToNextMonth}
-            today={today}
+            duration={duration}
             schedules={schedules}
-            size="large"
+            selectDate={selectDate}
+            selectedDate={selectedDate}
           />
         </S.Left>
         <S.Right>
-          <S.DailyButton type="button">매일</S.DailyButton>
-          <S.DayBox>
-            <span className="sun">일</span>
-            <span>월</span>
-            <span>화</span>
-            <span>수</span>
-            <span>목</span>
-            <span>금</span>
-            <span className="sat">토</span>
-          </S.DayBox>
           <S.InputWrapper>
-            <S.Input type="time" />
+            <S.Input
+              type="time"
+              value={startTime}
+              onChange={setStartTime}
+              disabled={!selectedDate}
+            />
             부터
-            <S.Input type="time" onKeyPress={pressEnterToNext} />
+            <S.Input
+              type="time"
+              value={endTime}
+              onChange={setEndTime}
+              onKeyPress={pressEnterToNext}
+              disabled={!selectedDate}
+            />
             까지
           </S.InputWrapper>
-          <S.AddButton type="button">달력에 추가하기</S.AddButton>
+          <S.AddButton type="button" onClick={addSchedule}>
+            달력에 추가하기
+          </S.AddButton>
         </S.Right>
       </S.Content>
     </Container>

--- a/frontend/src/pages/Create/index.tsx
+++ b/frontend/src/pages/Create/index.tsx
@@ -44,6 +44,10 @@ function Create() {
     useDescriptionState,
     getGroupState,
   } = useCreateState();
+  const duration = {
+    start: getGroupState().startDate,
+    end: getGroupState().endDate,
+  };
   const [page, setPage] = useState(1);
   const pageRefs = useRef<Array<HTMLDivElement | null>>([]);
   const navigate = useNavigate();
@@ -129,6 +133,7 @@ function Create() {
         />
         <Step5
           useScheduleState={useScheduleState}
+          duration={duration}
           ref={getPageRef(5)}
           pressEnterToNext={pressEnterToNext}
         />

--- a/frontend/src/styles/global.tsx
+++ b/frontend/src/styles/global.tsx
@@ -47,6 +47,10 @@ const style = (theme: Theme) => css`
     font-family: 'GangwonEdu_Bold';
     font-size: 1.2rem;
 
+    &:disabled {
+      background: ${theme.colors.gray005};
+    }
+
     &:focus {
       border: 1.5px solid ${theme.colors.green002};
 


### PR DESCRIPTION
## Issue

- #195 

## Description (optional)

- 상세 페이지용 / 생성 페이지용 달력 나누기
- duration 기간을 달력에 반영하기
- 일자를 선택했을때 state에 담기 (selected)
- 시간 데이터랑 묶어서 state에 담기 (fixed)
- 추가된 schedule을 유저에게 보여주기

closed #195 