### PR TITLE
[FE] 달력 일정 호버 시 모달에 겹치면 모달이 계속 여닫히는 오류 해결

### DIFF
--- a/frontend/src/components/@shared/Calendar/SelectedDate/index.tsx
+++ b/frontend/src/components/@shared/Calendar/SelectedDate/index.tsx
@@ -20,7 +20,10 @@ function SelectedDate({ date, schedule }: DateProps) {
   return (
     <>
       {isHover && (
-        <S.TimeModal>
+        <S.TimeModal
+          onMouseOver={toggleHovering(true)}
+          onMouseOut={toggleHovering(false)}
+        >
           ⏰ {parsedTime(schedule?.startTime)} ~ {parsedTime(schedule?.endTime)}{' '}
           ⏰
         </S.TimeModal>

--- a/frontend/src/components/@shared/Calendar/SelectedDate/index.tsx
+++ b/frontend/src/components/@shared/Calendar/SelectedDate/index.tsx
@@ -13,7 +13,7 @@ interface DateProps {
 function SelectedDate({ date, schedule }: DateProps) {
   const [isHover, setIsHover] = useState(false);
 
-  const toggleHovering = (isHover: boolean) => () => {
+  const changeHoverState = (isHover: boolean) => () => {
     setIsHover(isHover);
   };
 
@@ -21,16 +21,16 @@ function SelectedDate({ date, schedule }: DateProps) {
     <>
       {isHover && (
         <S.TimeModal
-          onMouseOver={toggleHovering(true)}
-          onMouseOut={toggleHovering(false)}
+          onMouseOver={changeHoverState(true)}
+          onMouseOut={changeHoverState(false)}
         >
           ⏰ {parsedTime(schedule?.startTime)} ~ {parsedTime(schedule?.endTime)}{' '}
           ⏰
         </S.TimeModal>
       )}
       <S.SelectedDate
-        onMouseOver={toggleHovering(true)}
-        onMouseOut={toggleHovering(false)}
+        onMouseOver={changeHoverState(true)}
+        onMouseOut={changeHoverState(false)}
       >
         {date}
       </S.SelectedDate>


### PR DESCRIPTION
## Issue

- #201 

## Description (optional)

- 달력에서 일정이 있는 날짜에 호버 시 나오는 모달이 날짜와 겹치면 모달이 계속 여닫히는 현상이 발생하여 이를 해결하고자 함
- 모달에 호버 시 모달이 닫히지 않도록 추가

closed #201 