### PR TITLE
[BE] 로그 파일의 경로 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/config/AspectConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/AspectConfiguration.java
@@ -1,9 +1,35 @@
 package com.woowacourse.momo.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import com.woowacourse.momo.logging.ExceptionLogging;
+import com.woowacourse.momo.logging.LogFileManager;
+import com.woowacourse.momo.logging.Logging;
 
 @Configuration
 @EnableAspectJAutoProxy
 public class AspectConfiguration {
+
+    @Value("${logging.file-path}")
+    private String logFilePath;
+
+    @Bean
+    public LogFileManager logFileManager() {
+        return new LogFileManager(logFilePath);
+    }
+
+    @Bean
+    public Logging logging() {
+        return new Logging(logFileManager());
+    }
+
+    @ConditionalOnExpression("${logging.show:true}")
+    @Bean
+    public ExceptionLogging exceptionLogging() {
+        return new ExceptionLogging(logging());
+    }
 }

--- a/backend/src/main/java/com/woowacourse/momo/config/AspectConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/AspectConfiguration.java
@@ -14,7 +14,7 @@ import com.woowacourse.momo.logging.Logging;
 @EnableAspectJAutoProxy
 public class AspectConfiguration {
 
-    @Value("${logging.file-path}")
+    @Value("${momo-logging.file-path}")
     private String logFilePath;
 
     @Bean
@@ -27,7 +27,7 @@ public class AspectConfiguration {
         return new Logging(logFileManager());
     }
 
-    @ConditionalOnExpression("${logging.show:true}")
+    @ConditionalOnExpression("${momo-logging.show:true}")
     @Bean
     public ExceptionLogging exceptionLogging() {
         return new ExceptionLogging(logging());

--- a/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
@@ -5,21 +5,35 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Aspect
 @Component
-public class ExceptionLogging extends Logging {
+public class ExceptionLogging {
+
+    private final Logging logging;
+
+    @Pointcut("execution(* com.woowacourse.momo..*.*(..))")
+    public void allMethod() {
+    }
+
+    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleException(..))")
+    public void exceptionMethod() {
+    }
 
     @AfterThrowing(value = "allMethod()", throwing = "exception")
     public void exceptionStackTrace(JoinPoint joinPoint, Exception exception) {
-        printExceptionStackTrace(joinPoint);
+        logging.printExceptionStackTrace(joinPoint);
     }
 
     @Around("exceptionMethod()")
     public Object exceptionMessage(ProceedingJoinPoint joinPoint) throws Throwable {
         Object result = joinPoint.proceed();
-        printExceptionMessage(joinPoint);
+        logging.printExceptionMessage(joinPoint);
         return result;
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
@@ -6,13 +6,11 @@ import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
-import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Aspect
-@Component
 public class ExceptionLogging {
 
     private final Logging logging;

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Value;
-
 import com.woowacourse.momo.logging.exception.LogException;
 
 public class LogFileManager {
@@ -26,7 +24,7 @@ public class LogFileManager {
 
     public void writeExceptionStackTrace(String exceptionStackTrace) {
         Date today = new Date();
-        String filePath = createDirectory(today);
+        String filePath = createFile(today);
         File file = new File(filePath);
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, IS_APPENDED))) {
@@ -39,7 +37,7 @@ public class LogFileManager {
 
     public void writeExceptionMessage(Exception exception) {
         Date today = new Date();
-        String filePath = createDirectory(today);
+        String filePath = createFile(today);
         File file = new File(filePath);
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, IS_APPENDED))) {
@@ -50,14 +48,14 @@ public class LogFileManager {
         }
     }
 
-    private String createDirectory(Date today) {
+    private String createFile(Date today) {
         File baseDirectory = new File(logPath);
-        createDirectoryOrFile(baseDirectory);
+        createDirectory(baseDirectory);
 
         return baseDirectory.getPath() + "/" + getLogFileName(today);
     }
 
-    private void createDirectoryOrFile(File file) {
+    private void createDirectory(File file) {
         if (!file.exists() && !file.mkdir()) {
             throw new LogException("로그 폴더 생성에 실패하였습니다");
         }

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -20,7 +20,7 @@ public class LogFileManager {
 
     private final String logPath;
 
-    public LogFileManager(@Value("${logging.file-path}") String logPath) {
+    public LogFileManager(@Value("${momo-logging.file-path}") String logPath) {
         this.logPath = logPath;
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -15,13 +15,11 @@ import com.woowacourse.momo.logging.exception.LogException;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LogFileManager {
 
-    private static final SimpleDateFormat YEAR_FOLDER_FORMAT = new SimpleDateFormat("yyyy");
-    private static final SimpleDateFormat MONTH_FOLDER_FORMAT = new SimpleDateFormat("MM");
     private static final SimpleDateFormat FILE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
     private static final SimpleDateFormat LOG_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     private static final String EXTENSION = ".txt";
-    private static final String LOG_DIRECTORY_BASE_PATH = "./src/log/";
+    private static final String LOG_DIRECTORY_BASE_PATH = "./momolog/";
 
     private static final boolean IS_APPENDED = true;
 
@@ -53,14 +51,9 @@ public class LogFileManager {
 
     private static String createDirectory(Date today) {
         File baseDirectory = new File(LOG_DIRECTORY_BASE_PATH);
-        File yearDirectory = new File(LOG_DIRECTORY_BASE_PATH + YEAR_FOLDER_FORMAT.format(today));
-        File monthDirectory = new File(yearDirectory + "/" + MONTH_FOLDER_FORMAT.format(today) + "/");
-
         createDirectoryOrFile(baseDirectory);
-        createDirectoryOrFile(yearDirectory);
-        createDirectoryOrFile(monthDirectory);
 
-        return monthDirectory.getPath() + "/" + getLogFileName(today);
+        return baseDirectory.getPath() + "/" + getLogFileName(today);
     }
 
     private static void createDirectoryOrFile(File file) {

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -7,23 +7,27 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import org.springframework.beans.factory.annotation.Value;
 
 import com.woowacourse.momo.logging.exception.LogException;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Component
 public class LogFileManager {
 
     private static final SimpleDateFormat FILE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
     private static final SimpleDateFormat LOG_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-
     private static final String EXTENSION = ".txt";
-    private static final String LOG_DIRECTORY_BASE_PATH = "./momolog/";
-
     private static final boolean IS_APPENDED = true;
 
-    public static void writeExceptionStackTrace(String exceptionStackTrace) {
+    private final String logPath;
+
+    public LogFileManager(@Value("${logging.file-path}") String logPath) {
+        this.logPath = logPath;
+    }
+
+    public void writeExceptionStackTrace(String exceptionStackTrace) {
         Date today = new Date();
         String filePath = createDirectory(today);
         File file = new File(filePath);
@@ -36,7 +40,7 @@ public class LogFileManager {
         }
     }
 
-    public static void writeExceptionMessage(Exception exception) {
+    public void writeExceptionMessage(Exception exception) {
         Date today = new Date();
         String filePath = createDirectory(today);
         File file = new File(filePath);
@@ -49,24 +53,24 @@ public class LogFileManager {
         }
     }
 
-    private static String createDirectory(Date today) {
-        File baseDirectory = new File(LOG_DIRECTORY_BASE_PATH);
+    private String createDirectory(Date today) {
+        File baseDirectory = new File(logPath);
         createDirectoryOrFile(baseDirectory);
 
         return baseDirectory.getPath() + "/" + getLogFileName(today);
     }
 
-    private static void createDirectoryOrFile(File file) {
+    private void createDirectoryOrFile(File file) {
         if (!file.exists() && !file.mkdir()) {
             throw new LogException("로그 폴더 생성에 실패하였습니다");
         }
     }
 
-    private static String getLogFileName(Date today) {
+    private String getLogFileName(Date today) {
         return FILE_FORMAT.format(today) + EXTENSION;
     }
 
-    private static void writeExceptionMessage(Exception exception, BufferedWriter writer, Date today) throws IOException {
+    private void writeExceptionMessage(Exception exception, BufferedWriter writer, Date today) throws IOException {
         writer.append(LOG_DATE_FORMAT.format(today))
                 .append(" ")
                 .append(String.valueOf(exception.getClass()))

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -20,7 +20,7 @@ public class LogFileManager {
 
     private final String logPath;
 
-    public LogFileManager(@Value("${momo-logging.file-path}") String logPath) {
+    public LogFileManager(String logPath) {
         this.logPath = logPath;
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -7,13 +7,10 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.springframework.stereotype.Component;
-
 import org.springframework.beans.factory.annotation.Value;
 
 import com.woowacourse.momo.logging.exception.LogException;
 
-@Component
 public class LogFileManager {
 
     private static final SimpleDateFormat FILE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");

--- a/backend/src/main/java/com/woowacourse/momo/logging/Logging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/Logging.java
@@ -3,31 +3,29 @@ package com.woowacourse.momo.logging;
 import java.util.Arrays;
 
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
 public class Logging {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Logging.class);
 
-    @Pointcut("execution(* com.woowacourse.momo..*.*(..))")
-    protected void allMethod() {
-    }
+    private final LogFileManager logFileManager;
 
-    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleException(..))")
-    protected void exceptionMethod() {
-    }
-
-    protected void printExceptionStackTrace(JoinPoint joinPoint) {
+    public void printExceptionStackTrace(JoinPoint joinPoint) {
         String logMessage = log(joinPoint);
         LOGGER.error(ConsolePrettier.red(logMessage));
-        LogFileManager.writeExceptionStackTrace(logMessage);
+        logFileManager.writeExceptionStackTrace(logMessage);
     }
 
-    protected void printExceptionMessage(JoinPoint joinPoint) {
+    public void printExceptionMessage(JoinPoint joinPoint) {
         LOGGER.error(ConsolePrettier.red("" + getException(joinPoint)));
-        LogFileManager.writeExceptionMessage(getException(joinPoint));
+        logFileManager.writeExceptionMessage(getException(joinPoint));
     }
 
     private String log(JoinPoint joinPoint) {

--- a/backend/src/main/java/com/woowacourse/momo/logging/Logging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/Logging.java
@@ -5,12 +5,10 @@ import java.util.Arrays;
 import org.aspectj.lang.JoinPoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Component
 public class Logging {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Logging.class);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -15,3 +15,4 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+  file-path: './momolog/'

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,9 +11,11 @@ spring:
 #      hibernate:
 #        format_sql: 'true'
 #    show-sql: 'true'
-
-logging:
+#
+#logging:
 #  level:
 #    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+momo-logging:
   show: 'true'
   file-path: './momolog/'

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -7,13 +7,6 @@ spring:
     hibernate:
       naming.physical-strategy: com.woowacourse.momo.config.CustomNamingStrategy
 
-    properties:
-      hibernate:
-        format_sql: 'true'
-    show-sql: 'true'
-
-logging:
-  level:
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+momo-logging:
   show: 'false'
   file-path: './momolog/'

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -15,5 +15,5 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-  show: 'true'
+  show: 'false'
   file-path: './momolog/'


### PR DESCRIPTION
# 😲 문제 발생
젠킨스를 사용하여 배포 자동화 과정에서, 백엔드 배포 서버에는 빌드가 완료된 `.jar` 파일만을 전송한다.
기존의 로그 파일 경로는 소스코드 내에 저장되었기 때문에 잘못된 경로로 인하여 문제가 발생하여 로그 파일의 경로를 수정한다.

# 🛠 상세 작업
 - 로그 파일들의 기본 경로 수정
   - 배포 서버와 로컬에서의 폴더 구조를 통일시키기 위해 `./momolog` 로 수정
   - 다른 로그 파일과 헷갈리지 않도록 `./log` 가 아닌 `./momolog` 사용
- 로그 폴더 내부 경로 수정
  - 터미널에서 로그 파일 관리 시 파일 접근이 번거롭다는 피드백 반영
- 로그 파일 경로를 appplication.yml 로 관리
- 테스트 코드 실행 시 로그 파일이 작성되는 것 제거
  - 테스트에서도 로그가 작성되는 문제가 발생
  - `AspectConfiguration` 에서 설정값을 호출하여 로그를 남기는지에 대한 여부 확인 후 로그 작성