### PR TITLE
[BE] 에러코드 추가 

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -1,103 +1,123 @@
-== 모모의 API 명세
+= 모모의 API 명세
+:toc: left
+:toclevels: 4
 
 == 카테고리
 
 === 카테고리 조회
 
-==== Request
+Request
 include::{snippets}/categorylist/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/categorylist/http-response.adoc[]
 
 == 모임
 
 === 모임 조회
 
-==== Request
+Request
 include::{snippets}/groupget/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/groupget/http-response.adoc[]
 
 === 모임 생성
 
-==== Request
+Request
 include::{snippets}/groupcreate/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/groupcreate/http-response.adoc[]
 
 === 모임 삭제
 
-==== Request
+Request
 include::{snippets}/groupdelete/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/groupdelete/http-response.adoc[]
 
 === 모든 모임 조회
 
-==== Request
+Request
 include::{snippets}/grouplist/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/grouplist/http-response.adoc[]
 
-==== 본인이 가입하거나 주최한 모임 조회
+=== 본인이 가입하거나 주최한 모임 조회
 
-==== Request
+Request
 include::{snippets}/grouprelated/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/grouprelated/http-response.adoc[]
 
 == 유저
 
 === 회원가입
 
-==== Request
+Request
 include::{snippets}/membersignup/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/membersignup/http-response.adoc[]
 
 === 로그인
 
-==== Request
+Request
 include::{snippets}/memberlogin/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/memberlogin/http-response.adoc[]
 
 === 회원 조회
 
-==== Request
+Request
 include::{snippets}/memberfind/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/memberfind/http-response.adoc[]
 
 === 회원 탈퇴
 
-==== Request
+Request
 include::{snippets}/memberdelete/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/memberdelete/http-response.adoc[]
 
 === 회원 이름 변경
 
-==== Request
+Request
 include::{snippets}/memberupdatename/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/memberupdatename/http-response.adoc[]
 
 === 회원 비밀번호 변경
 
-==== Request
+Request
 include::{snippets}/memberupdatepassword/http-request.adoc[]
 
-==== Response
+Response
 include::{snippets}/memberupdatepassword/http-response.adoc[]
+
+== 그룹 참여
+
+=== 그룹 참여
+
+Request
+include::{snippets}/participate/http-request.adoc[]
+
+Response
+include::{snippets}/participate/http-response.adoc[]
+
+=== 그룹 참여자 목록 조회
+
+Request
+include::{snippets}/findparticipants/http-request.adoc[]
+
+Response
+include::{snippets}/findparticipants/http-response.adoc[]

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -15,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import com.woowacourse.momo.auth.exception.AuthFailException;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
@@ -41,7 +43,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     private void validateToken(HttpServletRequest request) {
         String token = AuthorizationExtractor.extract(request);
         if (!jwtTokenProvider.validateToken(token)) {
-            throw new AuthFailException("AUTH_ERROR_002"); // 유효하지 않는 토큰입니다.
+            throw new MomoException(ErrorCode.AUTH_INVALID_TOKEN);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -29,9 +29,16 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         Optional<Authenticated> authenticated = parseAnnotation((HandlerMethod) handler, Authenticated.class);
         if (authenticated.isPresent()) {
+            validateContainsAuthorizationHeader(request);
             validateToken(request);
         }
         return true;
+    }
+
+    private void validateContainsAuthorizationHeader(HttpServletRequest request) {
+        if (request.getHeader("Authorization") == null) {
+            throw new AuthFailException("AUTH_ERROR_003"); // 인증이 필요한 접근입니다, 비회원이 접근 시 로그인이 필요한 경우
+        }
     }
 
     private <T extends Annotation> Optional<T> parseAnnotation(HandlerMethod handler, Class<T> clazz) {
@@ -41,7 +48,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     private void validateToken(HttpServletRequest request) {
         String token = AuthorizationExtractor.extract(request);
         if (!jwtTokenProvider.validateToken(token)) {
-            throw new AuthFailException("유효하지 않은 토큰입니다.");
+            throw new AuthFailException("AUTH_ERROR_002"); // 유효하지 않는 토큰입니다.
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -29,16 +29,9 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         Optional<Authenticated> authenticated = parseAnnotation((HandlerMethod) handler, Authenticated.class);
         if (authenticated.isPresent()) {
-            validateContainsAuthorizationHeader(request);
             validateToken(request);
         }
         return true;
-    }
-
-    private void validateContainsAuthorizationHeader(HttpServletRequest request) {
-        if (request.getHeader("Authorization") == null) {
-            throw new AuthFailException("AUTH_ERROR_003"); // 인증이 필요한 접근입니다, 비회원이 접근 시 로그인이 필요한 경우
-        }
     }
 
     private <T extends Annotation> Optional<T> parseAnnotation(HandlerMethod handler, Class<T> clazz) {

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
     }
 
     private void validateExistUser(String userId) {
-        if (memberRepository.findByUserId(userId) == null) {
+        if (memberRepository.findByUserId(userId) != null) {
             throw new IllegalArgumentException("SIGNUP_ERROR_003"); // 이미 가입된 아이디
         }
     }

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
@@ -26,7 +26,7 @@ public class AuthService {
     public LoginResponse login(LoginRequest request) {
         String password = passwordEncoder.encrypt(request.getPassword());
         Member member = memberRepository.findByUserIdAndPassword(request.getUserId(), password)
-                .orElseThrow(() -> new AuthFailException("로그인에 실패했습니다."));
+                .orElseThrow(() -> new AuthFailException("LOGIN_ERROR_001")); // 로그인에 실패했습니다
         String token = JwtTokenProvider.createToken(member.getId());
 
         return new LoginResponse(token);
@@ -35,6 +35,7 @@ public class AuthService {
     @Transactional
     public Long signUp(SignUpRequest request) {
         validateUserId(request.getUserId());
+        validateExistUser(request.getUserId());
         String password = passwordEncoder.encrypt(request.getPassword());
         Member member = new Member(request.getUserId(), password, request.getName());
         Member savedMember = memberRepository.save(member);
@@ -42,9 +43,15 @@ public class AuthService {
         return savedMember.getId();
     }
 
+    private void validateExistUser(String userId) {
+        if (memberRepository.findByUserId(userId) == null) {
+            throw new IllegalArgumentException("SIGNUP_ERROR_003"); // 이미 가입된 아이디
+        }
+    }
+
     private void validateUserId(String userId) {
         if (userId.contains("@")) {
-            throw new IllegalArgumentException("잘못된 아이디 형식입니다.");
+            throw new IllegalArgumentException("SIGNUP_ERROR_001"); // 잘못된 아이디 형식입니다.
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
@@ -11,6 +11,8 @@ import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 
@@ -26,7 +28,7 @@ public class AuthService {
     public LoginResponse login(LoginRequest request) {
         String password = passwordEncoder.encrypt(request.getPassword());
         Member member = memberRepository.findByUserIdAndPassword(request.getUserId(), password)
-                .orElseThrow(() -> new AuthFailException("LOGIN_ERROR_001")); // 로그인에 실패했습니다
+                .orElseThrow(() -> new MomoException(ErrorCode.LOGIN_INVALID_ID_AND_PASSWORD)); // 로그인에 실패했습니다
         String token = JwtTokenProvider.createToken(member.getId());
 
         return new LoginResponse(token);
@@ -45,13 +47,13 @@ public class AuthService {
 
     private void validateExistUser(String userId) {
         if (memberRepository.findByUserId(userId) != null) {
-            throw new IllegalArgumentException("SIGNUP_ERROR_003"); // 이미 가입된 아이디
+            throw new MomoException(ErrorCode.SIGNUP_ALREADY_REGISTER);
         }
     }
 
     private void validateUserId(String userId) {
         if (userId.contains("@")) {
-            throw new IllegalArgumentException("SIGNUP_ERROR_001"); // 잘못된 아이디 형식입니다.
+            throw new MomoException(ErrorCode.SIGNUP_INVALID_ID);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/dto/request/LoginRequest.java
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LoginRequest {
 
-    @NotBlank(message = "아이디는 빈 값일 수 없습니다.")
+    @NotBlank(message = "SIGNUP_ERROR_001") // 이메일은 빈 값일 수 없습니다.
     private String userId;
-    @NotBlank(message = "패스워드는 빈 값일 수 없습니다.")
+    @NotBlank(message = "SIGNUP_ERROR_002") // 비밀번호는 빈 값일 수 없습니다.
     private String password;
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -5,6 +5,8 @@ import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 
 import com.woowacourse.momo.auth.exception.AuthFailException;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 
 public class AuthorizationExtractor {
 
@@ -27,6 +29,6 @@ public class AuthorizationExtractor {
             }
         }
 
-        throw new AuthFailException("AUTH_ERROR_003"); // 토큰이 존재하지 않습니다.
+        throw new MomoException(ErrorCode.AUTH_REQUIRED_LOGIN);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -27,6 +27,6 @@ public class AuthorizationExtractor {
             }
         }
 
-        throw new AuthFailException("토큰이 존재하지 않습니다");
+        throw new AuthFailException("AUTH_ERROR_003"); // 토큰이 존재하지 않습니다.
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
@@ -9,11 +9,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+
+import com.woowacourse.momo.auth.exception.AuthFailException;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 
 @Component
 public class JwtTokenProvider {
@@ -50,6 +55,8 @@ public class JwtTokenProvider {
             Jws<Claims> claims = getClaims(token);
 
             return !claims.getBody().getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            throw new MomoException(ErrorCode.AUTH_EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }

--- a/backend/src/main/java/com/woowacourse/momo/config/AspectConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/config/AspectConfiguration.java
@@ -1,9 +1,35 @@
 package com.woowacourse.momo.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import com.woowacourse.momo.logging.ExceptionLogging;
+import com.woowacourse.momo.logging.LogFileManager;
+import com.woowacourse.momo.logging.Logging;
 
 @Configuration
 @EnableAspectJAutoProxy
 public class AspectConfiguration {
+
+    @Value("${momo-logging.file-path}")
+    private String logFilePath;
+
+    @Bean
+    public LogFileManager logFileManager() {
+        return new LogFileManager(logFilePath);
+    }
+
+    @Bean
+    public Logging logging() {
+        return new Logging(logFileManager());
+    }
+
+    @ConditionalOnExpression("${momo-logging.show:true}")
+    @Bean
+    public ExceptionLogging exceptionLogging() {
+        return new ExceptionLogging(logging());
+    }
 }

--- a/backend/src/main/java/com/woowacourse/momo/globalException/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/ControllerAdvice.java
@@ -6,17 +6,24 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.woowacourse.momo.globalException.dto.response.ExceptionResponse;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 
 @RestControllerAdvice
 public class ControllerAdvice {
 
-    @ExceptionHandler
-    public ResponseEntity<ExceptionResponse> handleException(Exception e) {
-        return ResponseEntity.badRequest().body(ExceptionResponse.from(e));
+    @ExceptionHandler(MomoException.class)
+    public ResponseEntity<ExceptionResponse> handleException(MomoException e) {
+        return ResponseEntity.status(e.getStatusCode()).body(ExceptionResponse.from(e.getErrorCode()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        return ResponseEntity.badRequest().body(ExceptionResponse.from(e));
+        return ResponseEntity.badRequest().body(ExceptionResponse.from(ErrorCode.VALIDATION_ERROR.getErrorCode()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionResponse> handleAnyException(Exception e) {
+        return ResponseEntity.internalServerError().body(ExceptionResponse.from(ErrorCode.INTERNAL_SERVER_ERROR.getErrorCode()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/globalException/dto/response/ExceptionResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/dto/response/ExceptionResponse.java
@@ -12,8 +12,8 @@ public class ExceptionResponse {
 
     private final String message;
 
-    public static ExceptionResponse from(Exception e) {
-        return new ExceptionResponse(e.getMessage());
+    public static ExceptionResponse from(String e) {
+        return new ExceptionResponse(e);
     }
 
     public static ExceptionResponse from(MethodArgumentNotValidException e) {
@@ -22,6 +22,7 @@ public class ExceptionResponse {
         for (FieldError error : e.getFieldErrors()) {
             message.append(error.getDefaultMessage()).append(" ");
         }
+
         return new ExceptionResponse(new String(message));
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
@@ -1,0 +1,42 @@
+package com.woowacourse.momo.globalException.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_001", "토큰의 유효기간이 만료되었습니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_002", "토큰이 유효하지 않습니다."),
+    AUTH_REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_003", "로그인이 필요합니다."),
+    AUTH_DELETE_NO_HOST(HttpStatus.FORBIDDEN.value(), "AUTH_ERROR_004", "주최자가 아닌 사람은 모임을 수정하거나 삭제할 수 없습니다."),
+    AUTH_DELETE_NO_PARTICIPANT(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_005", "참여자가 아닌 회원은 모임을 탈퇴할 수 없습니다."),
+
+    SIGNUP_INVALID_ID(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_001", "잘못된 형식의 아이디입니다."),
+    SIGNUP_INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_002", "잘못된 형식의 비밀번호입니다."),
+    SIGNUP_ALREADY_REGISTER(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_003", "이미 가입된 아이디입니다."),
+
+    LOGIN_INVALID_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST.value(), "LOGIN_ERROR_001", "아이디나 비밀번호가 다릅니다."),
+
+    GROUP_NOT_EXIST(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_001", "존재하지 않는 모임입니다."),
+    GROUP_DURATION_START_AFTER_END(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_002", "기간의 시작일은 종료일 이전이어야 합니다."),
+    GROUP_SCHEDULE_START_AFTER_END(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_003", "일정의 시작 시간은 종료 시간 이전이어야 합니다."),
+    GROUP_SCHEDULE_NOT_RANGE_DURATION(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_004", "일정이 모임 기간에 포함되어야 합니다."),
+    GROUP_DURATION_NOT_PAST(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_005", "시작일과 종료일은 과거일 수 없습니다."),
+    GROUP_DURATION_NOT_AFTER_DEADLINE(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_006", "마감시간이 시작 일자 이후일 수 없습니다."),
+    GROUP_DEADLINE_NOT_PAST(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_007", "마감시간이 과거일 수 없습니다."),
+    GROUP_MEMBERS_NOT_IN_RANGE(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_008", "모임 내 인원은 1명 이상 99명 이하여야 합니다."),
+    GROUP_ALREADY_FINISH(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_009", "모집 마감된 모임은 수정 및 삭제할 수 없습니다."),
+
+    PARTICIPANT_JOIN_BY_HOST(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_001", "주최자는 자신의 모임에 참여할 수 없습니다."),
+    PARTICIPANT_RE_PARTICIPATE(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_002", "참여자는 본인이 참여한 모임에 재참여할 수 없습니다."),
+    PARTICIPANT_FINISHED(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_003", "마감된 모임에는 참여할 수 없습니다.")
+    ;
+
+    private final int statusCode;
+    private final String errorCode;
+    private final String message;
+
+}

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
@@ -1,5 +1,7 @@
 package com.woowacourse.momo.globalException.exception;
 
+import java.sql.SQLException;
+
 import org.springframework.http.HttpStatus;
 
 import lombok.AllArgsConstructor;
@@ -8,6 +10,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR_001", "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER_ERROR_001", "내부 서버 오류입니다."),
+
+    MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_001", "멤버가 존재하지 않습니다."),
+
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_001", "토큰의 유효기간이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_002", "토큰이 유효하지 않습니다."),
     AUTH_REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_003", "로그인이 필요합니다."),

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/MomoException.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/MomoException.java
@@ -1,0 +1,18 @@
+package com.woowacourse.momo.globalException.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MomoException extends RuntimeException {
+
+    int statusCode;
+    String errorCode;
+    String message;
+
+    public MomoException(ErrorCode code) {
+        statusCode = code.getStatusCode();
+        errorCode = code.getErrorCode();
+        message = code.getMessage();
+    }
+
+}

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
@@ -32,13 +32,13 @@ public class Duration {
 
     private void validatePastDate(LocalDate startDate, LocalDate endDate) {
         if (startDate.isBefore(LocalDate.now()) || endDate.isBefore(LocalDate.now())) {
-            throw new InvalidDurationException("시작일과 종료일은 과거의 날짜가 될 수 없습니다.");
+            throw new InvalidDurationException("GROUP_ERROR_005"); // 시작일과 종료일은 과거의 날짜가 될 수 없습니다.
         }
     }
 
     private void validateEndIsNotBeforeStart(LocalDate startDate, LocalDate endDate) {
         if (endDate.isBefore(startDate)) {
-            throw new InvalidDurationException("시작일은 종료일 이후가 될 수 없습니다.");
+            throw new InvalidDurationException("GROUP_ERROR_002"); // 시작일은 종료일 이후가 될 수 없습니다.
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
@@ -10,6 +10,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.exception.InvalidDurationException;
 
 @Getter
@@ -32,13 +34,13 @@ public class Duration {
 
     private void validatePastDate(LocalDate startDate, LocalDate endDate) {
         if (startDate.isBefore(LocalDate.now()) || endDate.isBefore(LocalDate.now())) {
-            throw new InvalidDurationException("GROUP_ERROR_005"); // 시작일과 종료일은 과거의 날짜가 될 수 없습니다.
+            throw new MomoException(ErrorCode.GROUP_DURATION_NOT_PAST);
         }
     }
 
     private void validateEndIsNotBeforeStart(LocalDate startDate, LocalDate endDate) {
         if (endDate.isBefore(startDate)) {
-            throw new InvalidDurationException("GROUP_ERROR_002"); // 시작일은 종료일 이후가 될 수 없습니다.
+            throw new MomoException(ErrorCode.GROUP_DURATION_START_AFTER_END);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -92,7 +92,7 @@ public class Group {
 
         validateCapacity(capacity);
         validateDeadline(deadline, duration);
-        participate(host);
+        this.participants.add(new Participant(this, host));
         belongTo(schedules);
     }
 
@@ -113,7 +113,7 @@ public class Group {
 
     private void validateCapacity(int capacity) {
         if (GroupCapacityRange.isOutOfRange(capacity)) {
-            throw new IllegalArgumentException("모임 정원은 1명 이상 99명 이하여야 합니다.");
+            throw new IllegalArgumentException("GROUP_ERROR_008");
         }
     }
 
@@ -124,13 +124,13 @@ public class Group {
 
     private void validateFutureDeadline(LocalDateTime deadline) {
         if (deadline.isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("마감 시간은 현재 시간 이전일 수 없습니다.");
+            throw new IllegalArgumentException("GROUP_ERROR_007"); // 마감 시간은 현재 시간 이전일 수 없습니다.
         }
     }
 
     private void validateDeadlineIsBeforeStartDuration(LocalDateTime deadline, Duration duration) {
         if (duration.isAfterStartDate(deadline)) {
-            throw new IllegalArgumentException("마감 시간은 모임 시작 일자 이후일 수 없습니다.");
+            throw new IllegalArgumentException("GROUP_ERROR_006"); // 마감 시간이 모임 시작 일자 이후가 되어서는 안된다.
         }
     }
 
@@ -150,17 +150,24 @@ public class Group {
     private void validateParticipateAvailable(Member member) {
         validateFinishedRecruitment();
         validateReParticipate(member);
+        validateIsHost(member);
+    }
+
+    private void validateIsHost(Member member) {
+        if (member == host) {
+            throw new IllegalArgumentException("PARTICIPANT_ERROR_001"); // 주최자는 모임에 참여할 수 없습니다.
+        }
     }
 
     private void validateFinishedRecruitment() {
         if (isFinishedRecruitment()) {
-            throw new IllegalArgumentException("모집이 마감됐습니다.");
+            throw new IllegalArgumentException("PARTICIPANT_ERROR_003"); // 이미 마감된 모임입니다.
         }
     }
 
     private void validateReParticipate(Member member) {
         if (getParticipants().contains(member)) {
-            throw new IllegalArgumentException("이미 참여한 모임입니다.");
+            throw new IllegalArgumentException("PARTICIPANT_ERROR_002"); // 이미 참여한 모임입니다.
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -26,6 +26,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.category.domain.Category;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.duration.Duration;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
 import com.woowacourse.momo.member.domain.Member;
@@ -113,7 +115,7 @@ public class Group {
 
     private void validateCapacity(int capacity) {
         if (GroupCapacityRange.isOutOfRange(capacity)) {
-            throw new IllegalArgumentException("GROUP_ERROR_008");
+            throw new MomoException(ErrorCode.GROUP_MEMBERS_NOT_IN_RANGE);
         }
     }
 
@@ -124,13 +126,13 @@ public class Group {
 
     private void validateFutureDeadline(LocalDateTime deadline) {
         if (deadline.isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("GROUP_ERROR_007"); // 마감 시간은 현재 시간 이전일 수 없습니다.
+            throw new MomoException(ErrorCode.GROUP_DEADLINE_NOT_PAST);
         }
     }
 
     private void validateDeadlineIsBeforeStartDuration(LocalDateTime deadline, Duration duration) {
         if (duration.isAfterStartDate(deadline)) {
-            throw new IllegalArgumentException("GROUP_ERROR_006"); // 마감 시간이 모임 시작 일자 이후가 되어서는 안된다.
+            throw new MomoException(ErrorCode.GROUP_DURATION_NOT_AFTER_DEADLINE);
         }
     }
 
@@ -155,19 +157,19 @@ public class Group {
 
     private void validateIsHost(Member member) {
         if (member == host) {
-            throw new IllegalArgumentException("PARTICIPANT_ERROR_001"); // 주최자는 모임에 참여할 수 없습니다.
+            throw new MomoException(ErrorCode.PARTICIPANT_JOIN_BY_HOST);
         }
     }
 
     private void validateFinishedRecruitment() {
         if (isFinishedRecruitment()) {
-            throw new IllegalArgumentException("PARTICIPANT_ERROR_003"); // 이미 마감된 모임입니다.
+            throw new MomoException(ErrorCode.PARTICIPANT_FINISHED);
         }
     }
 
     private void validateReParticipate(Member member) {
         if (getParticipants().contains(member)) {
-            throw new IllegalArgumentException("PARTICIPANT_ERROR_002"); // 이미 참여한 모임입니다.
+            throw new MomoException(ErrorCode.PARTICIPANT_RE_PARTICIPATE);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
@@ -13,6 +13,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -40,7 +43,7 @@ public class Schedule {
 
     private void validateStartIsBeforeEnd(LocalTime startTime, LocalTime endTime) {
         if (!endTime.isAfter(startTime)) {
-            throw new IllegalArgumentException("GROUP_ERROR_003"); // 시작 시간은 종료 시간 이전이어야 합니다
+            throw new MomoException(ErrorCode.GROUP_SCHEDULE_START_AFTER_END);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
@@ -40,7 +40,12 @@ public class Schedule {
 
     private void validateStartIsBeforeEnd(LocalTime startTime, LocalTime endTime) {
         if (!endTime.isAfter(startTime)) {
-            throw new IllegalArgumentException("시작 시간은 종료 시간 이전이어야 합니다.");
+            throw new IllegalArgumentException("GROUP_ERROR_003"); // 시작 시간은 종료 시간 이전이어야 합니다
         }
+    }
+
+    public boolean checkInRange(LocalDate startDate, LocalDate endDate) {
+        return (date.isAfter(startDate) | date.isEqual(startDate))
+                && (date.isBefore(endDate) | date.isEqual(endDate));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/exception/NotFoundGroupException.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/exception/NotFoundGroupException.java
@@ -3,6 +3,6 @@ package com.woowacourse.momo.group.exception;
 public class NotFoundGroupException extends GroupException {
 
     public NotFoundGroupException() {
-        super("존재하지 않는 모임입니다.");
+        super("GROUP_ERROR_001"); // 존재하지 않는 그룹입니다.
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
@@ -10,6 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
 import com.woowacourse.momo.group.exception.NotFoundGroupException;
@@ -23,7 +25,7 @@ public class GroupFindService {
 
     public Group findGroup(Long id) {
         return groupRepository.findById(id)
-                .orElseThrow(NotFoundGroupException::new);
+                .orElseThrow(() -> new MomoException(ErrorCode.GROUP_NOT_EXIST));
     }
 
     public List<Group> findGroups() {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.category.domain.Category;
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.duration.Duration;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
@@ -84,7 +86,7 @@ public class GroupService {
         schedules.stream()
                 .filter(schedule -> !schedule.checkInRange(duration.getStartDate(), duration.getEndDate()))
                 .findAny()
-                .ifPresent(schedule -> { throw new IllegalArgumentException("GROUP_ERROR_004"); });
+                .ifPresent(schedule -> { throw new MomoException(ErrorCode.GROUP_SCHEDULE_NOT_RANGE_DURATION); } );
     }
 
     @Transactional
@@ -108,13 +110,13 @@ public class GroupService {
     private void validateHost(Group group, Long hostId) {
         Member host = memberFindService.findMember(hostId);
         if (!group.isSameHost(host)) {
-            throw new IllegalArgumentException("AUTH_ERROR_004"); // 해당 모임의 주최자가 아닙니다.
+            throw new MomoException(ErrorCode.AUTH_DELETE_NO_HOST);
         }
     }
 
     private void validateFinishedRecruitment(Group group) {
         if (group.isFinishedRecruitment()) {
-            throw new IllegalArgumentException("GROUP_ERROR_006"); // 모집 마감된 모임은 수정 및 삭제할 수 없습니다.
+            throw new MomoException(ErrorCode.GROUP_ALREADY_FINISH);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -82,7 +82,6 @@ public class GroupService {
     }
 
     private void validateSchedulesInDuration(List<Schedule> schedules, Duration duration) {
-        // 일정의 일자가 모임 기간에 포함되지 않습니다.
         schedules.stream()
                 .filter(schedule -> !schedule.checkInRange(duration.getStartDate(), duration.getEndDate()))
                 .findAny()

--- a/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
@@ -5,21 +5,33 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.springframework.stereotype.Component;
+import org.aspectj.lang.annotation.Pointcut;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Aspect
-@Component
-public class ExceptionLogging extends Logging {
+public class ExceptionLogging {
+
+    private final Logging logging;
+
+    @Pointcut("execution(* com.woowacourse.momo..*.*(..))")
+    public void allMethod() {
+    }
+
+    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleException(..))")
+    public void exceptionMethod() {
+    }
 
     @AfterThrowing(value = "allMethod()", throwing = "exception")
     public void exceptionStackTrace(JoinPoint joinPoint, Exception exception) {
-        printExceptionStackTrace(joinPoint);
+        logging.printExceptionStackTrace(joinPoint);
     }
 
     @Around("exceptionMethod()")
     public Object exceptionMessage(ProceedingJoinPoint joinPoint) throws Throwable {
         Object result = joinPoint.proceed();
-        printExceptionMessage(joinPoint);
+        logging.printExceptionMessage(joinPoint);
         return result;
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/LogFileManager.java
@@ -7,27 +7,24 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 import com.woowacourse.momo.logging.exception.LogException;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LogFileManager {
 
-    private static final SimpleDateFormat YEAR_FOLDER_FORMAT = new SimpleDateFormat("yyyy");
-    private static final SimpleDateFormat MONTH_FOLDER_FORMAT = new SimpleDateFormat("MM");
     private static final SimpleDateFormat FILE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
     private static final SimpleDateFormat LOG_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-
     private static final String EXTENSION = ".txt";
-    private static final String LOG_DIRECTORY_BASE_PATH = "./src/log/";
-
     private static final boolean IS_APPENDED = true;
 
-    public static void writeExceptionStackTrace(String exceptionStackTrace) {
+    private final String logPath;
+
+    public LogFileManager(String logPath) {
+        this.logPath = logPath;
+    }
+
+    public void writeExceptionStackTrace(String exceptionStackTrace) {
         Date today = new Date();
-        String filePath = createDirectory(today);
+        String filePath = createFile(today);
         File file = new File(filePath);
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, IS_APPENDED))) {
@@ -38,9 +35,9 @@ public class LogFileManager {
         }
     }
 
-    public static void writeExceptionMessage(Exception exception) {
+    public void writeExceptionMessage(Exception exception) {
         Date today = new Date();
-        String filePath = createDirectory(today);
+        String filePath = createFile(today);
         File file = new File(filePath);
 
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, IS_APPENDED))) {
@@ -51,29 +48,24 @@ public class LogFileManager {
         }
     }
 
-    private static String createDirectory(Date today) {
-        File baseDirectory = new File(LOG_DIRECTORY_BASE_PATH);
-        File yearDirectory = new File(LOG_DIRECTORY_BASE_PATH + YEAR_FOLDER_FORMAT.format(today));
-        File monthDirectory = new File(yearDirectory + "/" + MONTH_FOLDER_FORMAT.format(today) + "/");
+    private String createFile(Date today) {
+        File baseDirectory = new File(logPath);
+        createDirectory(baseDirectory);
 
-        createDirectoryOrFile(baseDirectory);
-        createDirectoryOrFile(yearDirectory);
-        createDirectoryOrFile(monthDirectory);
-
-        return monthDirectory.getPath() + "/" + getLogFileName(today);
+        return baseDirectory.getPath() + "/" + getLogFileName(today);
     }
 
-    private static void createDirectoryOrFile(File file) {
+    private void createDirectory(File file) {
         if (!file.exists() && !file.mkdir()) {
             throw new LogException("로그 폴더 생성에 실패하였습니다");
         }
     }
 
-    private static String getLogFileName(Date today) {
+    private String getLogFileName(Date today) {
         return FILE_FORMAT.format(today) + EXTENSION;
     }
 
-    private static void writeExceptionMessage(Exception exception, BufferedWriter writer, Date today) throws IOException {
+    private void writeExceptionMessage(Exception exception, BufferedWriter writer, Date today) throws IOException {
         writer.append(LOG_DATE_FORMAT.format(today))
                 .append(" ")
                 .append(String.valueOf(exception.getClass()))

--- a/backend/src/main/java/com/woowacourse/momo/logging/Logging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/Logging.java
@@ -3,31 +3,27 @@ package com.woowacourse.momo.logging;
 import java.util.Arrays;
 
 import org.aspectj.lang.JoinPoint;
-import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class Logging {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Logging.class);
 
-    @Pointcut("execution(* com.woowacourse.momo..*.*(..))")
-    protected void allMethod() {
-    }
+    private final LogFileManager logFileManager;
 
-    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleException(..))")
-    protected void exceptionMethod() {
-    }
-
-    protected void printExceptionStackTrace(JoinPoint joinPoint) {
+    public void printExceptionStackTrace(JoinPoint joinPoint) {
         String logMessage = log(joinPoint);
         LOGGER.error(ConsolePrettier.red(logMessage));
-        LogFileManager.writeExceptionStackTrace(logMessage);
+        logFileManager.writeExceptionStackTrace(logMessage);
     }
 
-    protected void printExceptionMessage(JoinPoint joinPoint) {
+    public void printExceptionMessage(JoinPoint joinPoint) {
         LOGGER.error(ConsolePrettier.red("" + getException(joinPoint)));
-        LogFileManager.writeExceptionMessage(getException(joinPoint));
+        logFileManager.writeExceptionMessage(getException(joinPoint));
     }
 
     private String log(JoinPoint joinPoint) {

--- a/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
@@ -27,7 +27,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Authenticated
     @GetMapping
     public ResponseEntity<MyInfoResponse> find(@AuthenticationPrincipal Long id) {
         MyInfoResponse response = memberService.findById(id);
@@ -35,7 +34,6 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
-    @Authenticated
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal Long id,
                                                @RequestBody @Valid ChangePasswordRequest request) {
@@ -44,7 +42,6 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Authenticated
     @PatchMapping("/name")
     public ResponseEntity<Void> updateName(@AuthenticationPrincipal Long id,
                                            @RequestBody @Valid ChangeNameRequest request) {
@@ -53,7 +50,6 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Authenticated
     @DeleteMapping
     public ResponseEntity<Void> delete(@AuthenticationPrincipal Long id) {
         memberService.deleteById(id);

--- a/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
@@ -27,6 +27,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @Authenticated
     @GetMapping
     public ResponseEntity<MyInfoResponse> find(@AuthenticationPrincipal Long id) {
         MyInfoResponse response = memberService.findById(id);
@@ -34,6 +35,7 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @Authenticated
     @PatchMapping("/password")
     public ResponseEntity<Void> updatePassword(@AuthenticationPrincipal Long id,
                                                @RequestBody @Valid ChangePasswordRequest request) {
@@ -42,6 +44,7 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Authenticated
     @PatchMapping("/name")
     public ResponseEntity<Void> updateName(@AuthenticationPrincipal Long id,
                                            @RequestBody @Valid ChangeNameRequest request) {
@@ -50,6 +53,7 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Authenticated
     @DeleteMapping
     public ResponseEntity<Void> delete(@AuthenticationPrincipal Long id) {
         memberService.deleteById(id);

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/MemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByUserIdAndPassword(String userId, String password);
+
+    Member findByUserId(String userId);
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
@@ -5,6 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.exception.NotFoundMemberException;
@@ -18,6 +20,6 @@ public class MemberFindService {
 
     public Member findMember(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(NotFoundMemberException::new);
+                .orElseThrow(() -> new MomoException(ErrorCode.MEMBER_NOT_EXIST));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/participant/controller/ParticipantController.java
+++ b/backend/src/main/java/com/woowacourse/momo/participant/controller/ParticipantController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.config.Authenticated;
 import com.woowacourse.momo.auth.config.AuthenticationPrincipal;
 import com.woowacourse.momo.member.service.dto.response.MemberResponse;
 import com.woowacourse.momo.participant.service.ParticipantService;
@@ -22,6 +23,7 @@ public class ParticipantController {
 
     private final ParticipantService participantService;
 
+    @Authenticated
     @PostMapping
     public ResponseEntity<Void> participate(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId) {
         participantService.participate(groupId, memberId);

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupCreateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupCreateAcceptanceTest.java
@@ -24,6 +24,6 @@ class GroupCreateAcceptanceTest extends AcceptanceTest {
     @DisplayName("비회원이 모임을 생성한다")
     @Test
     void createGroupByNonMember() {
-        모임을_생성한다(GROUP).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: UNAUTHORIZED
+        모임을_생성한다(GROUP).statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
@@ -38,14 +38,14 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteGroupByAnotherMember() {
         String anotherAccessToken = DUDU.로_로그인한다();
-        모임을_삭제한다(anotherAccessToken, groupId).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: UNAUTHORIZED
+        모임을_삭제한다(anotherAccessToken, groupId).statusCode(HttpStatus.FORBIDDEN.value());
         모임을_조회한다(hostAccessToken, groupId).statusCode(HttpStatus.OK.value());
     }
 
     @DisplayName("비회원이 모임을 삭제한다")
     @Test
     void deleteGroupByNonMember() {
-        모임을_삭제한다(groupId).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: UNAUTHORIZED
+        모임을_삭제한다(groupId).statusCode(HttpStatus.UNAUTHORIZED.value());
         모임을_조회한다(hostAccessToken, groupId).statusCode(HttpStatus.OK.value());
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
@@ -80,13 +80,13 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
     void updateGroupByAnotherMember() {
         String anotherAccessToken = DUDU.로_로그인한다();
         모임을_수정한다(anotherAccessToken, groupId, DUDU_STUDY).statusCode(
-                HttpStatus.BAD_REQUEST.value()); // TODO: UNAUTHORIZED
+                HttpStatus.FORBIDDEN.value());
     }
 
     @DisplayName("비회원이 모임을 수정한다")
     @Test
     void updateGroupByNonMember() {
-        모임을_수정한다(groupId, DUDU_STUDY).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: UNAUTHORIZED
+        모임을_수정한다(groupId, DUDU_STUDY).statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @DisplayName("존재하지 않은 모임을 삭제한다")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/participant/ParticipantAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/participant/ParticipantAcceptanceTest.java
@@ -60,7 +60,7 @@ class ParticipantAcceptanceTest extends AcceptanceTest {
     @DisplayName("비회원이 모임에 참여한다")
     @Test
     void participateByNonMember() {
-        모임에_참여한다(groupId).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: UNAUTHORIZED
+        모임에_참여한다(groupId).statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @DisplayName("정원이 가득 찬 모임에 참여한다")

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
@@ -73,7 +73,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("잘못된 아이디 형식입니다.")));
+                .andExpect(jsonPath("message", containsString("SIGNUP_ERROR_001")));
     }
 
     @DisplayName("비어있는 아이디 값으로 회원가입시 400코드가 반환된다")
@@ -153,7 +153,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("아이디는 빈 값일 수 없습니다.")));
+                .andExpect(jsonPath("message", containsString("SIGNUP_ERROR_001")));
     }
 
     @DisplayName("비어있는 비밀번호 형식으로 로그인시 400코드가 반환된다")
@@ -166,7 +166,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("패스워드는 빈 값일 수 없습니다.")));
+                .andExpect(jsonPath("message", containsString("SIGNUP_ERROR_002")));
     }
 
     void createNewMember(String userId, String password, String name) {

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
@@ -85,7 +85,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("아이디는 빈 값일 수 없습니다.")));
+                .andExpect(jsonPath("message", containsString("VALIDATION_ERROR_001")));
     }
 
     @DisplayName("비어있는 비밀번호 값으로 회원가입시 400코드가 반환된다")
@@ -97,7 +97,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("패스워드는 빈 값일 수 없습니다.")));
+                .andExpect(jsonPath("message", containsString("VALIDATION_ERROR_001")));
     }
 
     @DisplayName("잘못된 비밀번호 패턴으로 회원가입시 400코드가 반환된다")
@@ -109,7 +109,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("패스워드는 영문자와 하나 이상의 숫자, 특수 문자를 갖고 있어야 합니다.")));
+                .andExpect(jsonPath("message", containsString("VALIDATION_ERROR_001")));
     }
 
     @DisplayName("비어있는 이름 값으로 회원가입시 400코드가 반환된다")
@@ -121,7 +121,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("이름은 빈 값일 수 없습니다.")));
+                .andExpect(jsonPath("message", containsString("VALIDATION_ERROR_001")));
     }
 
     @DisplayName("정상적으로 로그인될 시 토큰이 발급된다")
@@ -153,7 +153,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("SIGNUP_ERROR_001")));
+                .andExpect(jsonPath("message", containsString("VALIDATION_ERROR_001")));
     }
 
     @DisplayName("비어있는 비밀번호 형식으로 로그인시 400코드가 반환된다")
@@ -166,7 +166,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("SIGNUP_ERROR_002")));
+                .andExpect(jsonPath("message", containsString("VALIDATION_ERROR_001")));
     }
 
     void createNewMember(String userId, String password, String name) {

--- a/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.woowacourse.momo.auth.exception.AuthFailException;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.globalException.exception.MomoException;
 
 @Transactional
 @SpringBootTest
@@ -49,7 +50,8 @@ class AuthServiceTest {
         LoginRequest request = new LoginRequest(USER_ID, "wrongPassword");
 
         assertThatThrownBy(() -> authService.login(request))
-                .isInstanceOf(AuthFailException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("아이디나 비밀번호가 다릅니다.");
     }
 
     void createMember(String userId, String password, String name) {

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
@@ -22,7 +22,7 @@ class DurationTest {
     void validateEndIsNotBeforeStart() {
         assertThatThrownBy(() -> new Duration(일주일후.getInstance(), 이틀후.getInstance()))
                 .isInstanceOf(InvalidDurationException.class)
-                .hasMessage("시작일은 종료일 이후가 될 수 없습니다.");
+                .hasMessage("GROUP_ERROR_002");
     }
 
     @DisplayName("시작일과 종료일은 과거의 날짜가 될 수 없다")
@@ -30,7 +30,7 @@ class DurationTest {
     void validatePastDate() {
         assertThatThrownBy(() -> new Duration(어제.getInstance(), 어제.getInstance()))
                 .isInstanceOf(InvalidDurationException.class)
-                .hasMessage("시작일과 종료일은 과거의 날짜가 될 수 없습니다.");
+                .hasMessage("GROUP_ERROR_005");
     }
 
     @DisplayName("시작일 이후의 일자일 경우 True를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
@@ -13,6 +13,7 @@ import static com.woowacourse.momo.fixture.DateTimeFixture.이틀후_23시_59분
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.exception.InvalidDurationException;
 
 class DurationTest {
@@ -21,16 +22,16 @@ class DurationTest {
     @Test
     void validateEndIsNotBeforeStart() {
         assertThatThrownBy(() -> new Duration(일주일후.getInstance(), 이틀후.getInstance()))
-                .isInstanceOf(InvalidDurationException.class)
-                .hasMessage("GROUP_ERROR_002");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("기간의 시작일은 종료일 이전이어야 합니다.");
     }
 
     @DisplayName("시작일과 종료일은 과거의 날짜가 될 수 없다")
     @Test
     void validatePastDate() {
         assertThatThrownBy(() -> new Duration(어제.getInstance(), 어제.getInstance()))
-                .isInstanceOf(InvalidDurationException.class)
-                .hasMessage("GROUP_ERROR_005");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("시작일과 종료일은 과거일 수 없습니다.");
     }
 
     @DisplayName("시작일 이후의 일자일 경우 True를 반환한다.")

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.woowacourse.momo.category.domain.Category;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
 import com.woowacourse.momo.member.domain.Member;
 
@@ -32,8 +33,8 @@ class GroupTest {
     @ValueSource(ints = {-1, 0, 100})
     void validateOutOfCapacityRange(int capacity) {
         assertThatThrownBy(() -> constructGroupWithSetCapacity(capacity))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("GROUP_ERROR_008");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("모임 내 인원은 1명 이상 99명 이하여야 합니다.");
     }
 
     @DisplayName("유효한 모임 정원 값으로 인스턴스 생성시 예외가 발생하지 않는다")
@@ -48,8 +49,8 @@ class GroupTest {
     void validatePastDeadline() {
         LocalDateTime deadline = LocalDateTime.now().minusMinutes(1);
         assertThatThrownBy(() -> constructGroupWithSetDeadline(deadline))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("GROUP_ERROR_007");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("마감시간이 과거일 수 없습니다.");
     }
 
     @DisplayName("유효한 마감기한 날짜로 인스턴스 생성시 예외가 발생하지 않는다")
@@ -64,8 +65,8 @@ class GroupTest {
     void validateDeadlineIsBeforeStartDuration() {
         LocalDateTime deadline = 일주일후_23시_59분.getInstance();
         assertThatThrownBy(() -> constructGroupWithSetDeadline(deadline))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("GROUP_ERROR_006");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("마감시간이 시작 일자 이후일 수 없습니다.");
     }
 
     @DisplayName("회원이 모임의 주최자일 경우 True 를 반환한다")
@@ -104,8 +105,8 @@ class GroupTest {
         Member member = new Member("momo", "qwer123!@#", "모모");
         group.participate(member);
         assertThatThrownBy(() -> group.participate(member))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("PARTICIPANT_ERROR_002");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("참여자는 본인이 참여한 모임에 재참여할 수 없습니다.");
     }
 
     @DisplayName("정원이 가득찬 모임에 참가할 경우 예외가 발생한다")
@@ -118,8 +119,8 @@ class GroupTest {
 
         Member member2 = new Member("dudu", "qwer123!@#", "두두");
         assertThatThrownBy(() -> group.participate(member2))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("PARTICIPANT_ERROR_003");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("마감된 모임에는 참여할 수 없습니다.");
     }
 
     @DisplayName("마감기한이 지난 모임에 참가할 경우 예외가 발생한다")
@@ -129,8 +130,8 @@ class GroupTest {
         Member member = new Member("momo@woowa.com", "qwer123!@#", "모모");
 
         assertThatThrownBy(() -> group.participate(member))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("PARTICIPANT_ERROR_003");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("마감된 모임에는 참여할 수 없습니다.");
     }
 
     @DisplayName("모임에 참여한 회원을 반환한다")

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
@@ -33,7 +33,7 @@ class GroupTest {
     void validateOutOfCapacityRange(int capacity) {
         assertThatThrownBy(() -> constructGroupWithSetCapacity(capacity))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("모임 정원은 1명 이상 99명 이하여야 합니다.");
+                .hasMessage("GROUP_ERROR_008");
     }
 
     @DisplayName("유효한 모임 정원 값으로 인스턴스 생성시 예외가 발생하지 않는다")
@@ -49,7 +49,7 @@ class GroupTest {
         LocalDateTime deadline = LocalDateTime.now().minusMinutes(1);
         assertThatThrownBy(() -> constructGroupWithSetDeadline(deadline))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("마감 시간은 현재 시간 이전일 수 없습니다.");
+                .hasMessage("GROUP_ERROR_007");
     }
 
     @DisplayName("유효한 마감기한 날짜로 인스턴스 생성시 예외가 발생하지 않는다")
@@ -65,7 +65,7 @@ class GroupTest {
         LocalDateTime deadline = 일주일후_23시_59분.getInstance();
         assertThatThrownBy(() -> constructGroupWithSetDeadline(deadline))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("마감 시간은 모임 시작 일자 이후일 수 없습니다.");
+                .hasMessage("GROUP_ERROR_006");
     }
 
     @DisplayName("회원이 모임의 주최자일 경우 True 를 반환한다")
@@ -105,7 +105,7 @@ class GroupTest {
         group.participate(member);
         assertThatThrownBy(() -> group.participate(member))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 참여한 모임입니다.");
+                .hasMessage("PARTICIPANT_ERROR_002");
     }
 
     @DisplayName("정원이 가득찬 모임에 참가할 경우 예외가 발생한다")
@@ -119,7 +119,7 @@ class GroupTest {
         Member member2 = new Member("dudu", "qwer123!@#", "두두");
         assertThatThrownBy(() -> group.participate(member2))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("모집이 마감됐습니다.");
+                .hasMessage("PARTICIPANT_ERROR_003");
     }
 
     @DisplayName("마감기한이 지난 모임에 참가할 경우 예외가 발생한다")
@@ -130,7 +130,7 @@ class GroupTest {
 
         assertThatThrownBy(() -> group.participate(member))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("모집이 마감됐습니다.");
+                .hasMessage("PARTICIPANT_ERROR_003");
     }
 
     @DisplayName("모임에 참여한 회원을 반환한다")

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/schedule/ScheduleTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/schedule/ScheduleTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.woowacourse.momo.globalException.exception.MomoException;
+
 class ScheduleTest {
 
     private static Stream<Arguments> provideForScheduleValidator() {
@@ -28,7 +30,7 @@ class ScheduleTest {
     @MethodSource("provideForScheduleValidator")
     void validateStartIsBeforeEnd(LocalTime startTime, LocalTime endTime) {
         assertThatThrownBy(() -> new Schedule(이틀후.getInstance(), startTime, endTime))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("GROUP_ERROR_003");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("일정의 시작 시간은 종료 시간 이전이어야 합니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/schedule/ScheduleTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/schedule/ScheduleTest.java
@@ -29,6 +29,6 @@ class ScheduleTest {
     void validateStartIsBeforeEnd(LocalTime startTime, LocalTime endTime) {
         assertThatThrownBy(() -> new Schedule(이틀후.getInstance(), startTime, endTime))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("시작 시간은 종료 시간 이전이어야 합니다.");
+                .hasMessage("GROUP_ERROR_003");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -141,7 +141,7 @@ class GroupServiceTest {
 
         assertThatThrownBy(() -> groupService.update(savedMember.getId(), groupId, groupRequest))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("모집 마감된 모임은 수정 및 삭제할 수 없습니다.");
+                .hasMessage("GROUP_ERROR_006");
     }
 
     @DisplayName("모임을 조기 마감한다")
@@ -198,6 +198,6 @@ class GroupServiceTest {
 
         assertThatThrownBy(() -> groupService.delete(savedMember.getId(), groupId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("모집 마감된 모임은 수정 및 삭제할 수 없습니다.");
+                .hasMessage("GROUP_ERROR_006");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.category.domain.Category;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
 import com.woowacourse.momo.group.exception.NotFoundGroupException;
@@ -110,7 +111,8 @@ class GroupServiceTest {
     @Test
     void findByIdWithNotExistGroupId() {
         assertThatThrownBy(() -> groupService.findById(0L))
-                .isInstanceOf(NotFoundGroupException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("존재하지 않는 모임입니다.");
     }
 
     @DisplayName("모임 목록을 조회한다")
@@ -140,8 +142,8 @@ class GroupServiceTest {
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         assertThatThrownBy(() -> groupService.update(savedMember.getId(), groupId, groupRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("GROUP_ERROR_006");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("모집 마감된 모임은 수정 및 삭제할 수 없습니다.");
     }
 
     @DisplayName("모임을 조기 마감한다")
@@ -184,7 +186,8 @@ class GroupServiceTest {
         groupService.delete(savedMember.getId(), groupId);
 
         assertThatThrownBy(() -> groupService.findById(groupId))
-                .isInstanceOf(NotFoundGroupException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("존재하지 않는 모임입니다.");
     }
 
     @DisplayName("모집 마김된 모임을 삭제할 경우 예외가 발생한다.")
@@ -197,7 +200,7 @@ class GroupServiceTest {
         long groupId = savedGroup.getId();
 
         assertThatThrownBy(() -> groupService.delete(savedMember.getId(), groupId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("GROUP_ERROR_006");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("모집 마감된 모임은 수정 및 삭제할 수 없습니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.exception.NotFoundMemberException;
@@ -83,7 +84,8 @@ class MemberServiceTest {
         memberService.deleteById(memberId);
 
         assertThatThrownBy(() -> memberService.findById(memberId))
-                .isInstanceOf(NotFoundMemberException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("멤버가 존재하지 않습니다.");
     }
 
     private Long createMember() {

--- a/backend/src/test/java/com/woowacourse/momo/participant/controller/ParticipantControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/controller/ParticipantControllerTest.java
@@ -93,7 +93,7 @@ public class ParticipantControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("존재하지 않는 모임입니다.")))
+                .andExpect(jsonPath("$.message", is("GROUP_ERROR_001")))
                 .andDo(
                         document("participatenotexistgroup",
                                 preprocessRequest(prettyPrint()),
@@ -139,7 +139,7 @@ public class ParticipantControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("이미 참여한 모임입니다.")))
+                .andExpect(jsonPath("$.message", is("PARTICIPANT_ERROR_002")))
                 .andDo(
                         document("participateparticipant",
                                 preprocessRequest(prettyPrint()),
@@ -161,7 +161,7 @@ public class ParticipantControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("모집이 마감됐습니다.")))
+                .andExpect(jsonPath("$.message", is("PARTICIPANT_ERROR_003")))
                 .andDo(
                         document("participatefullgroup",
                                 preprocessRequest(prettyPrint()),
@@ -195,7 +195,7 @@ public class ParticipantControllerTest {
         mockMvc.perform(get("/api/groups/" + 0 + "/participants")
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("존재하지 않는 모임입니다.")))
+                .andExpect(jsonPath("$.message", is("GROUP_ERROR_001")))
                 .andDo(
                         document("findparticipantsnotexistgroup",
                                 preprocessRequest(prettyPrint()),

--- a/backend/src/test/java/com/woowacourse/momo/participant/controller/ParticipantControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/controller/ParticipantControllerTest.java
@@ -116,7 +116,7 @@ public class ParticipantControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("존재하지 않는 회원입니다.")))
+                .andExpect(jsonPath("$.message", is("MEMBER_ERROR_001")))
                 .andDo(
                         document("participatenotexistmember",
                                 preprocessRequest(prettyPrint()),

--- a/backend/src/test/java/com/woowacourse/momo/participant/service/ParticipantServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/service/ParticipantServiceTest.java
@@ -97,7 +97,7 @@ class ParticipantServiceTest {
 
         assertThatThrownBy(() -> participantService.participate(savedGroup.getId(), participant1.getId()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 참여한 모임입니다.");
+                .hasMessage("PARTICIPANT_ERROR_002");
     }
 
     @DisplayName("모임 정원이 가득 찬 경우 참여를 할 수 없다")
@@ -109,7 +109,7 @@ class ParticipantServiceTest {
 
         assertThatThrownBy(() -> participantService.participate(savedGroup.getId(), participant2.getId()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("모집이 마감됐습니다.");
+                .hasMessage("PARTICIPANT_ERROR_003");
     }
 
     @DisplayName("모임의 참여자 목록을 조회한다")

--- a/backend/src/test/java/com/woowacourse/momo/participant/service/ParticipantServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/service/ParticipantServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.woowacourse.momo.category.domain.Category;
+import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
 import com.woowacourse.momo.group.exception.NotFoundGroupException;
@@ -77,7 +78,8 @@ class ParticipantServiceTest {
     @Test
     void participateNotExistGroup() {
         assertThatThrownBy(() -> participantService.participate(0L, participant1.getId()))
-                .isInstanceOf(NotFoundGroupException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("존재하지 않는 모임입니다.");
     }
 
     @DisplayName("존재하지 않는 사용자는 모임에 참여할 수 없다")
@@ -86,7 +88,8 @@ class ParticipantServiceTest {
         Group savedGroup = saveGroup();
 
         assertThatThrownBy(() -> participantService.participate(savedGroup.getId(), 0L))
-                .isInstanceOf(NotFoundMemberException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("멤버가 존재하지 않습니다.");
     }
 
     @DisplayName("모임에 이미 속해있을 경우 모임에 참여할 수 없다")
@@ -96,8 +99,8 @@ class ParticipantServiceTest {
         participantService.participate(savedGroup.getId(), participant1.getId());
 
         assertThatThrownBy(() -> participantService.participate(savedGroup.getId(), participant1.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("PARTICIPANT_ERROR_002");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("참여자는 본인이 참여한 모임에 재참여할 수 없습니다.");
     }
 
     @DisplayName("모임 정원이 가득 찬 경우 참여를 할 수 없다")
@@ -108,8 +111,8 @@ class ParticipantServiceTest {
         participantService.participate(savedGroup.getId(), participant1.getId());
 
         assertThatThrownBy(() -> participantService.participate(savedGroup.getId(), participant2.getId()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("PARTICIPANT_ERROR_003");
+                .isInstanceOf(MomoException.class)
+                .hasMessage("마감된 모임에는 참여할 수 없습니다.");
     }
 
     @DisplayName("모임의 참여자 목록을 조회한다")
@@ -130,6 +133,7 @@ class ParticipantServiceTest {
     @Test
     void findParticipantsNotExistGroup() {
         assertThatThrownBy(() -> participantService.findParticipants(0L))
-                .isInstanceOf(NotFoundGroupException.class);
+                .isInstanceOf(MomoException.class)
+                .hasMessage("존재하지 않는 모임입니다.");
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -7,15 +7,6 @@ spring:
     hibernate:
       naming.physical-strategy: com.woowacourse.momo.config.CustomNamingStrategy
 
-#    properties:
-#      hibernate:
-#        format_sql: 'true'
-#    show-sql: 'true'
-#
-#logging:
-#  level:
-#    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-
 momo-logging:
-  show: 'true'
+  show: 'false'
   file-path: './momolog/'


### PR DESCRIPTION
issue #180 
발생할 수 있는 모든 예외 클래스를 MomoException으로 통일하고,
에러 관련 정보들(응답 코드, 에러 코드, 에러 메시지)를 ErrorCode 클래스에 enum 형식으로 추가하였습니다.

또한, MomoException에서 ErrorCode를 매개변수로 받게 하고 ControllerAdvice에서는 MomoException의 응답 코드와 에러 코드만으로 Response를 구성하도록 하였습니다🫠

단, dto의 Valid 관련 예외에 대해서는.. 현재 처리하기 애매하다고 느껴져서 공통적으로 ErrorCode의 VALIDATION_ERROR를 반환하도록 하였습니다~