### PR TITLE
[FE] 오늘 시작인 모임 생성시 마감기한을 설정할 수 없는 오류 해결

### DIFF
--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -34,11 +34,15 @@ const convertDeadlineToRemainTime = (deadline: GroupDetailData['deadline']) => {
 };
 
 const getNewDateString = (until: 'day' | 'min') => {
+  const nowTime = new Date();
+  const offset = nowTime.getTimezoneOffset() * 60 * 1000;
+  const timeInKorea = new Date(nowTime.getTime() - offset);
+
   switch (until) {
     case 'day':
-      return new Date().toISOString().slice(0, 10);
+      return timeInKorea.toISOString().slice(0, 10);
     case 'min':
-      return new Date().toISOString().slice(0, 16);
+      return timeInKorea.toISOString().slice(0, 16);
   }
 };
 


### PR DESCRIPTION
## Issue

- #216 

## Description (optional)

- 오늘 시작인 모임 생성시 마감기한을 설정할 수 없는 오류 해결
![image](https://user-images.githubusercontent.com/28296575/183465494-85288f16-a389-4161-8dca-0799be46808a.png)

closed #216 