### PR TITLE
[BE] 모임 수정, 모임 삭제 기능을 참여자가 없을 경우에만 가능하도록 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     GROUP_DEADLINE_NOT_PAST(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_007", "마감시간이 과거일 수 없습니다."),
     GROUP_MEMBERS_NOT_IN_RANGE(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_008", "모임 내 인원은 1명 이상 99명 이하여야 합니다."),
     GROUP_ALREADY_FINISH(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_009", "모집 마감된 모임은 수정 및 삭제할 수 없습니다."),
+    GROUP_EXIST_PARTICIPANTS(HttpStatus.BAD_REQUEST.value(), "GROUP_ERROR_010", "참여자가 존재하는 모임은 수정 및 삭제할 수 없습니다."),
 
     PARTICIPANT_JOIN_BY_HOST(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_001", "주최자는 자신의 모임에 참여할 수 없습니다."),
     PARTICIPANT_RE_PARTICIPATE(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_002", "참여자는 본인이 참여한 모임에 재참여할 수 없습니다."),

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -188,7 +188,7 @@ public class Group {
         this.isEarlyClosed = true;
     }
 
-    public boolean isThereParticipants() {
+    public boolean isExistParticipants() {
         return participants.size() > NONE_PARTICIPANT;
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -100,8 +100,9 @@ public class Group {
         belongTo(schedules);
     }
 
-    public void update(Category category, int capacity, Duration duration, LocalDateTime deadline,
+    public void update(String name, Category category, int capacity, Duration duration, LocalDateTime deadline,
                        List<Schedule> schedules, String location, String description) {
+        this.name = name;
         this.category = category;
         this.capacity = capacity;
         this.duration = duration;

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -38,6 +38,8 @@ import com.woowacourse.momo.participant.domain.Participant;
 @Entity
 public class Group {
 
+    private static final int NONE_PARTICIPANT = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -183,6 +185,10 @@ public class Group {
 
     public void closeEarly() {
         this.isEarlyClosed = true;
+    }
+
+    public boolean isThereParticipants() {
+        return participants.size() > NONE_PARTICIPANT;
     }
 
     public List<Schedule> getSchedules() {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -101,6 +101,7 @@ public class GroupService {
     public void delete(Long hostId, Long groupId) {
         Group group = groupFindService.findGroup(groupId);
         validateHost(group, hostId);
+        validateNotExistParticipants(group);
         validateFinishedRecruitment(group);
 
         groupRepository.deleteById(groupId);
@@ -110,6 +111,12 @@ public class GroupService {
         Member host = memberFindService.findMember(hostId);
         if (!group.isSameHost(host)) {
             throw new MomoException(ErrorCode.AUTH_DELETE_NO_HOST);
+        }
+    }
+
+    private void validateNotExistParticipants(Group group) {
+        if (!group.isThereParticipants()) {
+            throw new MomoException(ErrorCode.GROUP_EXIST_PARTICIPANTS);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -116,7 +116,7 @@ public class GroupService {
     }
 
     private void validateNotExistParticipants(Group group) {
-        if (group.isThereParticipants()) {
+        if (group.isExistParticipants()) {
             throw new MomoException(ErrorCode.GROUP_EXIST_PARTICIPANTS);
         }
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -69,9 +69,7 @@ public class GroupService {
     @Transactional
     public void update(Long hostId, Long groupId, GroupUpdateRequest request) {
         Group group = groupFindService.findGroup(groupId);
-        validateHost(group, hostId);
-        validateFinishedRecruitment(group);
-        validateNotExistParticipants(group);
+        validateInitialState(hostId, group);
 
         List<Schedule> schedules = GroupRequestAssembler.schedules(request.getSchedules());
         Duration duration = GroupRequestAssembler.duration(request.getDuration());
@@ -101,11 +99,15 @@ public class GroupService {
     @Transactional
     public void delete(Long hostId, Long groupId) {
         Group group = groupFindService.findGroup(groupId);
+        validateInitialState(hostId, group);
+
+        groupRepository.deleteById(groupId);
+    }
+
+    private void validateInitialState(Long hostId, Group group) {
         validateHost(group, hostId);
         validateFinishedRecruitment(group);
         validateNotExistParticipants(group);
-
-        groupRepository.deleteById(groupId);
     }
 
     private void validateHost(Group group, Long hostId) {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -77,7 +77,7 @@ public class GroupService {
         Duration duration = GroupRequestAssembler.duration(request.getDuration());
         validateSchedulesInDuration(schedules, duration);
 
-        group.update(Category.from(request.getCategoryId()), request.getCapacity(),
+        group.update(request.getName(), Category.from(request.getCategoryId()), request.getCapacity(),
                 duration, request.getDeadline(), schedules,
                 request.getLocation(), request.getDescription());
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -71,6 +71,7 @@ public class GroupService {
         Group group = groupFindService.findGroup(groupId);
         validateHost(group, hostId);
         validateFinishedRecruitment(group);
+        validateNotExistParticipants(group);
 
         List<Schedule> schedules = GroupRequestAssembler.schedules(request.getSchedules());
         Duration duration = GroupRequestAssembler.duration(request.getDuration());
@@ -101,8 +102,8 @@ public class GroupService {
     public void delete(Long hostId, Long groupId) {
         Group group = groupFindService.findGroup(groupId);
         validateHost(group, hostId);
-        validateNotExistParticipants(group);
         validateFinishedRecruitment(group);
+        validateNotExistParticipants(group);
 
         groupRepository.deleteById(groupId);
     }
@@ -115,7 +116,7 @@ public class GroupService {
     }
 
     private void validateNotExistParticipants(Group group) {
-        if (!group.isThereParticipants()) {
+        if (group.isThereParticipants()) {
             throw new MomoException(ErrorCode.GROUP_EXIST_PARTICIPANTS);
         }
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupUpdateRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/dto/request/GroupUpdateRequest.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GroupUpdateRequest {
 
+    private String name;
     private Long categoryId;
     private Integer capacity;
     private DurationRequest duration;

--- a/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
+++ b/backend/src/main/java/com/woowacourse/momo/logging/ExceptionLogging.java
@@ -19,7 +19,7 @@ public class ExceptionLogging {
     public void allMethod() {
     }
 
-    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleException(..))")
+    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleAnyException(..))")
     public void exceptionMethod() {
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
@@ -21,16 +21,12 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
     private static final MemberFixture PARTICIPANT = MemberFixture.DUDU;
 
     private String hostAccessToken;
-    private String participantAccessToken;
     private Long groupId;
 
     @BeforeEach
     void setUp() {
         hostAccessToken = HOST.로_로그인한다();
-        participantAccessToken = PARTICIPANT.로_로그인한다();
-
         groupId = GROUP.을_생성한다(hostAccessToken);
-        모임에_참여한다(participantAccessToken, groupId);
     }
 
     @DisplayName("주최자가 모임을 삭제한다")
@@ -60,5 +56,15 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
     void deleteNonExistentGroup() {
         모임을_조회한다(hostAccessToken, 0L).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: NOT_FOUND
         모임을_삭제한다(hostAccessToken, 0L).statusCode(HttpStatus.BAD_REQUEST.value()); // TODO: NOT_FOUND
+    }
+
+    @DisplayName("참여자가 있는 모임을 삭제한다")
+    @Test
+    void deleteExistParticipant() {
+        String participantAccessToken = PARTICIPANT.로_로그인한다();
+        모임에_참여한다(participantAccessToken, groupId);
+
+        모임을_삭제한다(hostAccessToken, groupId).statusCode(HttpStatus.BAD_REQUEST.value());
+        모임을_조회한다(hostAccessToken, groupId).statusCode(HttpStatus.OK.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.momo.acceptance.group;
 
 import static com.woowacourse.momo.acceptance.group.GroupRestHandler.모임을_삭제한다;
 import static com.woowacourse.momo.acceptance.group.GroupRestHandler.모임을_조회한다;
+import static com.woowacourse.momo.acceptance.participant.ParticipantRestHandler.모임에_참여한다;
 import static com.woowacourse.momo.fixture.MemberFixture.DUDU;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -17,14 +18,19 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
 
     private static final GroupFixture GROUP = GroupFixture.MOMO_STUDY;
     private static final MemberFixture HOST = MemberFixture.MOMO;
+    private static final MemberFixture PARTICIPANT = MemberFixture.DUDU;
 
     private String hostAccessToken;
+    private String participantAccessToken;
     private Long groupId;
 
     @BeforeEach
     void setUp() {
         hostAccessToken = HOST.로_로그인한다();
+        participantAccessToken = PARTICIPANT.로_로그인한다();
+
         groupId = GROUP.을_생성한다(hostAccessToken);
+        모임에_참여한다(participantAccessToken, groupId);
     }
 
     @DisplayName("주최자가 모임을 삭제한다")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupRestHandler.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupRestHandler.java
@@ -96,16 +96,16 @@ public class GroupRestHandler extends RestHandler {
     }
 
     public static GroupUpdateRequest groupUpdateRequest(GroupFixture group) {
-        return groupUpdateRequest(group.getCategoryId(), group.getCapacity(), group.getDuration(), group.getSchedules(),
+        return groupUpdateRequest(group.getName(), group.getCategoryId(), group.getCapacity(), group.getDuration(), group.getSchedules(),
                 group.getDeadline(), group.getLocation(), group.getDescription());
     }
 
-    public static GroupUpdateRequest groupUpdateRequest(Long categoryId, Integer capacity, Duration duration,
+    public static GroupUpdateRequest groupUpdateRequest(String name, Long categoryId, Integer capacity, Duration duration,
                                                         List<Schedule> schedules, LocalDateTime deadline,
                                                         String location, String description) {
         DurationRequest durationRequest = durationRequest(duration);
         List<ScheduleRequest> scheduleRequests = scheduleRequests(schedules);
-        return new GroupUpdateRequest(categoryId, capacity, durationRequest, scheduleRequests, deadline, location,
+        return new GroupUpdateRequest(name, categoryId, capacity, durationRequest, scheduleRequests, deadline, location,
                 description);
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.momo.acceptance.group;
 
+import static com.woowacourse.momo.acceptance.participant.ParticipantRestHandler.모임에_참여한다;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -28,6 +29,7 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
 
     private static final GroupFixture GROUP = GroupFixture.MOMO_STUDY;
     private static final MemberFixture HOST = MemberFixture.MOMO;
+    private static final MemberFixture PARTICIPANT = MemberFixture.DUDU;
 
     private String hostAccessToken;
     private Long groupId;
@@ -103,5 +105,14 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
         ValidatableResponse response = GroupRestHandler.모임을_조회한다(groupId)
                 .statusCode(HttpStatus.OK.value())
                 .body("finished", is(true));
+    }
+
+    @DisplayName("참여자가 있는 모임을 수정한다")
+    @Test
+    void updateExistParticipant() {
+        String participantAccessToken = PARTICIPANT.로_로그인한다();
+        모임에_참여한다(participantAccessToken, groupId);
+
+        모임을_수정한다(hostAccessToken, groupId, DUDU_STUDY).statusCode(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
@@ -101,7 +101,7 @@ class GroupControllerTest {
         Long saveMemberId = saveMember("woowa", "wooteco1!", "모모");
         String accessToken = accessToken("woowa", "wooteco1!");
         Long savedGroupId = saveGroup("모모의 스터디", saveMemberId);
-        GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 15,
+        GroupUpdateRequest groupRequest = new GroupUpdateRequest("두두의 스터디", 1L, 15,
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         mockMvc.perform(put("/api/groups/" + savedGroupId)
@@ -246,9 +246,5 @@ class GroupControllerTest {
     Long saveMember(String id, String password, String name) {
         SignUpRequest request = new SignUpRequest(id, password, name);
         return authService.signUp(request);
-    }
-
-    void participate(Long groupId, Long memberId) {
-        participantService.participate(groupId, memberId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
@@ -140,8 +140,10 @@ class GroupControllerTest {
     @DisplayName("그룹이 정상적으로 삭제되는 경우를 테스트한다")
     @Test
     void groupDeleteTest() throws Exception {
-        Long saveMemberId = saveMember("woowa", "wooteco1!", "모모");
-        Long saveId = saveGroup("모모의 스터디", saveMemberId);
+        Long saveHostId = saveMember("woowa", "wooteco1!", "모모");
+        Long saveId = saveGroup("모모의 스터디", saveHostId);
+        Long saveParticipantId = saveMember("참여자", "wooteco1!", "모모");
+        participate(saveId, saveParticipantId);
         String accessToken = accessToken("woowa", "wooteco1!");
 
         mockMvc.perform(delete("/api/groups/" + saveId)
@@ -246,5 +248,9 @@ class GroupControllerTest {
     Long saveMember(String id, String password, String name) {
         SignUpRequest request = new SignUpRequest(id, password, name);
         return authService.signUp(request);
+    }
+
+    void participate(Long groupId, Long memberId) {
+        participantService.participate(groupId, memberId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupControllerTest.java
@@ -142,8 +142,6 @@ class GroupControllerTest {
     void groupDeleteTest() throws Exception {
         Long saveHostId = saveMember("woowa", "wooteco1!", "모모");
         Long saveId = saveGroup("모모의 스터디", saveHostId);
-        Long saveParticipantId = saveMember("참여자", "wooteco1!", "모모");
-        participate(saveId, saveParticipantId);
         String accessToken = accessToken("woowa", "wooteco1!");
 
         mockMvc.perform(delete("/api/groups/" + saveId)

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
@@ -9,8 +9,6 @@ import static com.woowacourse.momo.fixture.DateTimeFixture.어제_23시_59분;
 import static com.woowacourse.momo.fixture.DateTimeFixture.일주일후_23시_59분;
 import static com.woowacourse.momo.fixture.DurationFixture.이틀후부터_일주일후까지;
 import static com.woowacourse.momo.fixture.ScheduleFixture.이틀후_10시부터_12시까지;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
@@ -147,7 +145,7 @@ class GroupTest {
         assertThat(participants).contains(host, member);
     }
 
-    @DisplayName("현재 참여 인원이 정원을 초과하면 모집이 종료된다.")
+    @DisplayName("현재 참여 인원이 정원을 초과하면 모집이 종료된다")
     @Test
     void isFinishedRecruitmentWithOverCapacity() {
         int capacity = 2;
@@ -184,7 +182,7 @@ class GroupTest {
         Group group = constructGroup();
         group.participate(participant);
 
-        assertTrue(group.isExistParticipants());
+        assertThat(group.isExistParticipants()).isTrue();
     }
 
     @DisplayName("주최자를 제외하고 참여자가 없을 경우 False 를 반환한다")
@@ -192,7 +190,7 @@ class GroupTest {
     void isExistParticipantsFalse() {
         Group group = constructGroup();
 
-        assertFalse(group.isExistParticipants());
+        assertThat(group.isExistParticipants()).isFalse();
     }
 
     private Group constructGroup() {

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
@@ -180,19 +180,19 @@ class GroupTest {
 
     @DisplayName("주최자를 제외하고 참여자가 있을 경우 True 를 반환한다")
     @Test
-    void isThereParticipantsTrue() {
+    void isExistParticipantsTrue() {
         Group group = constructGroup();
         group.participate(participant);
 
-        assertTrue(group.isThereParticipants());
+        assertTrue(group.isExistParticipants());
     }
 
     @DisplayName("주최자를 제외하고 참여자가 없을 경우 False 를 반환한다")
     @Test
-    void isThereParticipantsFalse() {
+    void isExistParticipantsFalse() {
         Group group = constructGroup();
 
-        assertFalse(group.isThereParticipants());
+        assertFalse(group.isExistParticipants());
     }
 
     private Group constructGroup() {

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
@@ -9,6 +9,8 @@ import static com.woowacourse.momo.fixture.DateTimeFixture.어제_23시_59분;
 import static com.woowacourse.momo.fixture.DateTimeFixture.일주일후_23시_59분;
 import static com.woowacourse.momo.fixture.DurationFixture.이틀후부터_일주일후까지;
 import static com.woowacourse.momo.fixture.ScheduleFixture.이틀후_10시부터_12시까지;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
@@ -27,6 +29,7 @@ import com.woowacourse.momo.member.domain.Member;
 class GroupTest {
 
     private final Member host = new Member("주최자", "password", "momo");
+    private final Member participant = new Member("참여자", "password", "momo");
 
     @DisplayName("유효하지 않은 모임 정원 값으로 인스턴스 생성시 예외가 발생한다")
     @ParameterizedTest
@@ -92,8 +95,7 @@ class GroupTest {
     @Test
     void participate() {
         Group group = constructGroup();
-        Member member = new Member("momo", "qwer123!@#", "모모");
-        group.participate(member);
+        group.participate(participant);
 
         assertThat(group.getParticipants()).hasSize(2);
     }
@@ -176,6 +178,23 @@ class GroupTest {
         assertThat(actual).isTrue();
     }
 
+    @DisplayName("주최자를 제외하고 참여자가 있을 경우 True 를 반환한다")
+    @Test
+    void isThereParticipantsTrue() {
+        Group group = constructGroup();
+        group.participate(participant);
+
+        assertTrue(group.isThereParticipants());
+    }
+
+    @DisplayName("주최자를 제외하고 참여자가 없을 경우 False 를 반환한다")
+    @Test
+    void isThereParticipantsFalse() {
+        Group group = constructGroup();
+
+        assertFalse(group.isThereParticipants());
+    }
+
     private Group constructGroup() {
         return constructGroupWithSetCapacity(10);
     }
@@ -198,10 +217,11 @@ class GroupTest {
         Group group = new Group("momo 회의", host, Category.STUDY, 10, 이틀후부터_일주일후까지.getInstance(),
                 내일_23시_59분.getInstance(), schedules, "", "");
 
+        int deadlineField = 8;
         Class<Group> clazz = Group.class;
         Field[] field = clazz.getDeclaredFields();
-        field[7].setAccessible(true);
-        field[7].set(group, deadline);
+        field[deadlineField].setAccessible(true);
+        field[deadlineField].set(group, deadline);
 
         return group;
     }

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -141,14 +141,14 @@ class GroupServiceTest {
     @Test
     void update() {
         Group savedGroup = saveGroup();
-        GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 2,
+        GroupUpdateRequest groupRequest = new GroupUpdateRequest("두두의 스터디", 1L, 2,
             DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         groupService.update(savedHost.getId(), savedGroup.getId(), groupRequest);
 
         assertThat(groupService.findById(savedGroup.getId()))
             .usingRecursiveComparison()
-            .ignoringFields("name", "host", "finished")
+            .ignoringFields("host", "finished")
             .isEqualTo(groupRequest);
     }
 
@@ -157,7 +157,7 @@ class GroupServiceTest {
     void updateExistParticipants() {
         Group savedGroup = saveGroup();
         savedGroup.participate(savedMember1);
-        GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 2,
+        GroupUpdateRequest groupRequest = new GroupUpdateRequest("두두의 스터디", 1L, 2,
             DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         assertThatThrownBy(() -> groupService.update(savedHost.getId(), savedGroup.getId(), groupRequest))
@@ -173,7 +173,7 @@ class GroupServiceTest {
         savedGroup.participate(savedMember2);
         long groupId = savedGroup.getId();
 
-        GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 2,
+        GroupUpdateRequest groupRequest = new GroupUpdateRequest("두두의 스터디", 1L, 2,
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
         assertThatThrownBy(() -> groupService.update(savedHost.getId(), groupId, groupRequest))

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -27,7 +27,6 @@ import com.woowacourse.momo.category.domain.Category;
 import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
-import com.woowacourse.momo.group.exception.NotFoundGroupException;
 import com.woowacourse.momo.group.service.dto.request.DurationRequest;
 import com.woowacourse.momo.group.service.dto.request.GroupRequest;
 import com.woowacourse.momo.group.service.dto.request.GroupUpdateRequest;
@@ -38,6 +37,7 @@ import com.woowacourse.momo.group.service.dto.response.GroupResponseAssembler;
 import com.woowacourse.momo.group.service.dto.response.GroupSummaryResponse;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
+import com.woowacourse.momo.participant.service.ParticipantService;
 
 @Transactional
 @SpringBootTest
@@ -59,15 +59,22 @@ class GroupServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    private Member savedMember;
+    @Autowired
+    private ParticipantService participantService;
+
+    private Member savedHost;
+    private Member savedMember1;
+    private Member savedMember2;
 
     @BeforeEach
     void setUp() {
-        savedMember = memberRepository.save(new Member("회원", "password", "momo"));
+        savedHost = memberRepository.save(new Member("주최자", "password", "momo"));
+        savedMember1 = memberRepository.save(new Member("사용자1", "password", "momo"));
+        savedMember2 = memberRepository.save(new Member("사용자2", "password", "momo"));
     }
 
     private Group saveGroup() {
-        return groupRepository.save(new Group("모모의 스터디", savedMember, Category.STUDY, 2,
+        return groupRepository.save(new Group("모모의 스터디", savedHost, Category.STUDY, 3,
                 이틀후부터_일주일후까지.getInstance(), 내일_23시_59분.getInstance(), List.of(이틀후_10시부터_12시까지.newInstance()),
                 "", ""));
     }
@@ -78,7 +85,7 @@ class GroupServiceTest {
         GroupRequest request = new GroupRequest("모모의 스터디", Category.STUDY.getId(), 10,
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
-        groupService.create(savedMember.getId(), request);
+        groupService.create(savedHost.getId(), request);
 
         assertThat(groupRepository.findAll()).hasSize(1);
     }
@@ -90,7 +97,7 @@ class GroupServiceTest {
         GroupRequest request = new GroupRequest("모모의 스터디", categoryId, 10, DURATION_REQUEST,
                 SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
-        assertThatThrownBy(() -> groupService.create(savedMember.getId(), request))
+        assertThatThrownBy(() -> groupService.create(savedHost.getId(), request))
                 .isInstanceOf(NoSuchElementException.class)
                 .hasMessage("카테고리를 찾을 수 없습니다.");
     }
@@ -134,14 +141,14 @@ class GroupServiceTest {
     @Test
     void updateFinishedRecruitmentGroup() {
         Group savedGroup = saveGroup();
-        Member savedMember2 = memberRepository.save(new Member("회원2", "password", "dudu"));
+        savedGroup.participate(savedMember1);
         savedGroup.participate(savedMember2);
         long groupId = savedGroup.getId();
 
         GroupUpdateRequest groupRequest = new GroupUpdateRequest(1L, 2,
                 DURATION_REQUEST, SCHEDULE_REQUESTS, 내일_23시_59분.getInstance(), "", "");
 
-        assertThatThrownBy(() -> groupService.update(savedMember.getId(), groupId, groupRequest))
+        assertThatThrownBy(() -> groupService.update(savedHost.getId(), groupId, groupRequest))
                 .isInstanceOf(MomoException.class)
                 .hasMessage("모집 마감된 모임은 수정 및 삭제할 수 없습니다.");
     }
@@ -151,13 +158,13 @@ class GroupServiceTest {
     void closeEarly() {
         Group savedGroup = saveGroup();
 
-        groupService.closeEarly(savedMember.getId(), savedGroup.getId());
+        groupService.closeEarly(savedHost.getId(), savedGroup.getId());
 
         boolean actual = groupService.findById(savedGroup.getId()).isFinished();
         assertThat(actual).isTrue();
     }
 
-    @DisplayName("모임 목록중 두번째 페이지를 조회한다.")
+    @DisplayName("모임 목록중 두번째 페이지를 조회한다")
     @Test
     void findAllWithPage() {
         for (int i = 0; i < PAGE_SIZE; i++) {
@@ -178,28 +185,49 @@ class GroupServiceTest {
         );
     }
 
-
     @DisplayName("식별자를 통해 모임을 삭제한다")
     @Test
     void delete() {
         long groupId = saveGroup().getId();
-        groupService.delete(savedMember.getId(), groupId);
+        participantService.participate(groupId, savedMember1.getId());
+        groupService.delete(savedHost.getId(), groupId);
 
         assertThatThrownBy(() -> groupService.findById(groupId))
                 .isInstanceOf(MomoException.class)
                 .hasMessage("존재하지 않는 모임입니다.");
     }
 
-    @DisplayName("모집 마김된 모임을 삭제할 경우 예외가 발생한다.")
+    @DisplayName("주최자가 아닌 사용자가 모임을 삭제할 경우 예외가 발생한다")
+    @Test
+    void deleteNotHost() {
+        long memberId = savedMember1.getId();
+        long groupId = saveGroup().getId();
+
+        assertThatThrownBy(() -> groupService.delete(memberId, groupId))
+            .isInstanceOf(MomoException.class)
+            .hasMessage("주최자가 아닌 사람은 모임을 수정하거나 삭제할 수 없습니다.");
+    }
+
+    @DisplayName("주최자를 제외하고 참여자가 없을 경우 모임을 삭제하면 예외가 발생한다")
+    @Test
+    void deleteNotExistParticipants() {
+        long groupId = saveGroup().getId();
+
+        assertThatThrownBy(() -> groupService.delete(savedHost.getId(), groupId))
+            .isInstanceOf(MomoException.class)
+            .hasMessage("참여자가 존재하는 모임은 수정 및 삭제할 수 없습니다.");
+    }
+
+    @DisplayName("모집 마김된 모임을 삭제할 경우 예외가 발생한다")
     @Test
     void deleteFinishedRecruitmentGroup() {
         Group savedGroup = saveGroup();
-        Member savedMember2 = memberRepository.save(new Member("회원2", "password", "dudu"));
+        savedGroup.participate(savedMember1);
         savedGroup.participate(savedMember2);
 
         long groupId = savedGroup.getId();
 
-        assertThatThrownBy(() -> groupService.delete(savedMember.getId(), groupId))
+        assertThatThrownBy(() -> groupService.delete(savedHost.getId(), groupId))
                 .isInstanceOf(MomoException.class)
                 .hasMessage("모집 마감된 모임은 수정 및 삭제할 수 없습니다.");
     }


### PR DESCRIPTION
Issue #219 

## 🌟 구현할 기능
기존에 모임에 참여자가 있더라도 수정, 삭제가 가능했던 것에서
참여자가 주최자를 제외하고도 존재한다면 수정, 삭제를 할 수 없도록 변경한다.

## ⚒️ 작업 내용
- [x] 모임 수정 기능 변경
  - [x] 주최자를 제외한 참여자가 있을 경우에 모임 정보 수정 불가
  - [x] 참여자가 없을 경우 모임의 모든 정보 수정 가능
- [x] 모임 삭제 기능 변경
  - [x] 주최자를 제외한 참여자가 있을 경우에 모임 삭제 불가
  - [x] 참여자가 없을 경우 모임 삭제 가능