### PR TITLE
[BE] Oauth 인증 Redirect Uri 생성방식을 반응형으로 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
@@ -2,6 +2,7 @@ package com.woowacourse.momo.auth.config;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -15,6 +16,9 @@ import com.woowacourse.momo.auth.support.JwtTokenProvider;
 @Configuration
 public class AuthConfiguration implements WebMvcConfigurer {
 
+    @Value("${oauth2.redirect-path}")
+    private String redirectPath;
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
@@ -26,5 +30,6 @@ public class AuthConfiguration implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new TokenResolver(jwtTokenProvider));
+        resolvers.add(new OauthResolver(redirectPath));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
@@ -2,7 +2,6 @@ package com.woowacourse.momo.auth.config;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -16,9 +15,6 @@ import com.woowacourse.momo.auth.support.JwtTokenProvider;
 @Configuration
 public class AuthConfiguration implements WebMvcConfigurer {
 
-    @Value("${oauth2.redirect-path}")
-    private String redirectPath;
-
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
@@ -30,6 +26,5 @@ public class AuthConfiguration implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new TokenResolver(jwtTokenProvider));
-        resolvers.add(new OauthResolver(redirectPath));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthConfiguration.java
@@ -18,6 +18,7 @@ public class OauthConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new OauthResolver(redirectPath));
+        resolvers.add(new OauthRedirectUrlResolver(redirectPath));
+        resolvers.add(new OauthRequestUrlResolver());
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthConfiguration.java
@@ -1,0 +1,23 @@
+package com.woowacourse.momo.auth.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class OauthConfiguration implements WebMvcConfigurer {
+
+    @Value("${oauth2.redirect-path}")
+    private String redirectPath;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new OauthResolver(redirectPath));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRedirectUrl.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRedirectUrl.java
@@ -1,0 +1,11 @@
+package com.woowacourse.momo.auth.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OauthRedirectUrl {
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRedirectUrlResolver.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRedirectUrlResolver.java
@@ -8,11 +8,11 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-public class OauthResolver implements HandlerMethodArgumentResolver {
+public class OauthRedirectUrlResolver implements HandlerMethodArgumentResolver {
 
     private final String redirectPath;
 
-    public OauthResolver(String redirectPath) {
+    public OauthRedirectUrlResolver(String redirectPath) {
         this.redirectPath = redirectPath;
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRequestUrl.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRequestUrl.java
@@ -1,0 +1,11 @@
+package com.woowacourse.momo.auth.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OauthRequestUrl {
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRequestUrlResolver.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthRequestUrlResolver.java
@@ -1,0 +1,28 @@
+package com.woowacourse.momo.auth.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class OauthRequestUrlResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(OauthRequestUrl.class);
+    }
+
+    @Override
+    public String resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return extractRequestUrl((ServletWebRequest) webRequest);
+    }
+
+    private String extractRequestUrl(ServletWebRequest request) {
+        return request.getRequest()
+                .getRequestURL()
+                .toString();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthResolver.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthResolver.java
@@ -24,13 +24,13 @@ public class OauthResolver implements HandlerMethodArgumentResolver {
     @Override
     public String resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        String protocol = extractProtocl((ServletWebRequest) webRequest);
+        String protocol = extractProtocol((ServletWebRequest) webRequest);
         String domainHost = webRequest.getHeader(HttpHeaders.HOST);
 
         return protocol + "://" + domainHost + redirectPath;
     }
 
-    private String extractProtocl(ServletWebRequest request) {
+    private String extractProtocol(ServletWebRequest request) {
         return request.getRequest()
                 .getScheme();
     }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/OauthResolver.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/OauthResolver.java
@@ -1,0 +1,37 @@
+package com.woowacourse.momo.auth.config;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class OauthResolver implements HandlerMethodArgumentResolver {
+
+    private final String redirectPath;
+
+    public OauthResolver(String redirectPath) {
+        this.redirectPath = redirectPath;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(OauthRedirectUrl.class);
+    }
+
+    @Override
+    public String resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String protocol = extractProtocl((ServletWebRequest) webRequest);
+        String domainHost = webRequest.getHeader(HttpHeaders.HOST);
+
+        return protocol + "://" + domainHost + redirectPath;
+    }
+
+    private String extractProtocl(ServletWebRequest request) {
+        return request.getRequest()
+                .getScheme();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/controller/OauthController.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/controller/OauthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.config.OauthRedirectUrl;
 import com.woowacourse.momo.auth.service.OauthService;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.auth.service.dto.response.OauthLinkResponse;
@@ -20,8 +21,8 @@ public class OauthController {
     private final OauthService oauthService;
 
     @GetMapping("/login")
-    public ResponseEntity<OauthLinkResponse> access() {
-        OauthLinkResponse response = oauthService.generateAuthUrl();
+    public ResponseEntity<OauthLinkResponse> access(@OauthRedirectUrl String redirectUrl) {
+        OauthLinkResponse response = oauthService.generateAuthUrl(redirectUrl);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/controller/OauthController.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/controller/OauthController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.config.OauthRedirectUrl;
+import com.woowacourse.momo.auth.config.OauthRequestUrl;
 import com.woowacourse.momo.auth.service.OauthService;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.auth.service.dto.response.OauthLinkResponse;
@@ -27,8 +28,8 @@ public class OauthController {
     }
 
     @GetMapping(value = "/login", params = {"code"})
-    public ResponseEntity<LoginResponse> login(@RequestParam String code) {
-        LoginResponse loginResponse = oauthService.requestAccessToken(code);
+    public ResponseEntity<LoginResponse> login(@RequestParam String code, @OauthRequestUrl String requestUrl) {
+        LoginResponse loginResponse = oauthService.requestAccessToken(code, requestUrl);
         return ResponseEntity.ok(loginResponse);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
@@ -37,16 +37,16 @@ public class OauthService {
         return new OauthLinkResponse(oauthLink);
     }
 
-    public LoginResponse requestAccessToken(String code) {
-        GoogleUserResponse response = requestUserInfo(code);
+    public LoginResponse requestAccessToken(String code, String requestUrl) {
+        GoogleUserResponse response = requestUserInfo(code, requestUrl);
 
         Long memberId = findOrSaveMember(response);
         String token = jwtTokenProvider.createToken(memberId);
         return new LoginResponse(token);
     }
 
-    private GoogleUserResponse requestUserInfo(String code) {
-        ResponseEntity<GoogleUserResponse> responseEntity = oauthConnector.requestUserInfo(code);
+    private GoogleUserResponse requestUserInfo(String code, String requestUrl) {
+        ResponseEntity<GoogleUserResponse> responseEntity = oauthConnector.requestUserInfo(code, requestUrl);
 
         validateResponseStatusOk(responseEntity.getStatusCode());
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
@@ -32,8 +32,8 @@ public class OauthService {
     private final GoogleConnector oauthConnector;
     private final GoogleProvider oauthProvider;
 
-    public OauthLinkResponse generateAuthUrl() {
-        String oauthLink = oauthProvider.generateAuthUrl();
+    public OauthLinkResponse generateAuthUrl(String redirectUrl) {
+        String oauthLink = oauthProvider.generateAuthUrl(redirectUrl);
         return new OauthLinkResponse(oauthLink);
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
@@ -34,8 +34,8 @@ public class GoogleConnector {
 
     private final GoogleProvider provider;
 
-    public ResponseEntity<GoogleUserResponse> requestUserInfo(String code) {
-        String googleToken = requestAccessToken(code);
+    public ResponseEntity<GoogleUserResponse> requestUserInfo(String code, String requestUrl) {
+        String googleToken = requestAccessToken(code, requestUrl);
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", String.join(" ", BEARER_TYPE, googleToken));
@@ -44,8 +44,8 @@ public class GoogleConnector {
         return REST_TEMPLATE.exchange(provider.getUserInfoUrl(), HttpMethod.GET, entity, GoogleUserResponse.class);
     }
 
-    private String requestAccessToken(String code) {
-        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(createBody(code), createHeaders());
+    private String requestAccessToken(String code, String requestUrl) {
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(createBody(code, requestUrl), createHeaders());
 
         ResponseEntity<GoogleTokenResponse> response = REST_TEMPLATE.postForEntity(provider.getAccessTokenUrl(),
                 entity, GoogleTokenResponse.class);
@@ -60,12 +60,12 @@ public class GoogleConnector {
         return headers;
     }
 
-    private MultiValueMap<String, String> createBody(String code) {
+    private MultiValueMap<String, String> createBody(String code, String requestUrl) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("code", code);
         body.add("client_id", provider.getClientId());
         body.add("client_secret", provider.getClientSecret());
-        body.add("redirect_uri", provider.getRedirectUrl());
+        body.add("redirect_uri", requestUrl);
         body.add("grant_type", provider.getGrantType());
         return body;
     }

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleProvider.java
@@ -13,7 +13,6 @@ import lombok.Getter;
 @Component
 public class GoogleProvider {
 
-    private final String redirectUrl;
     private final String clientId;
     private final String clientSecret;
     private final String authUrl;
@@ -23,8 +22,7 @@ public class GoogleProvider {
     private final String scope;
     private final String temporaryPassword;
 
-    public GoogleProvider(@Value("${oauth2.url.redirect}") String redirectUrl,
-                          @Value("${oauth2.google.client.id}") String clientId,
+    public GoogleProvider(@Value("${oauth2.google.client.id}") String clientId,
                           @Value("${oauth2.google.client.secret}") String clientSecret,
                           @Value("${oauth2.google.url.auth}") String authUrl,
                           @Value("${oauth2.google.url.token}") String accessTokenUrl,
@@ -32,7 +30,6 @@ public class GoogleProvider {
                           @Value("${oauth2.google.grant-type}") String grantType,
                           @Value("${oauth2.google.scope}") String scope,
                           @Value("${oauth2.member.temporary-password}") String temporaryPassword) {
-        this.redirectUrl = redirectUrl;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.authUrl = authUrl;

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleProvider.java
@@ -43,7 +43,7 @@ public class GoogleProvider {
         this.temporaryPassword = temporaryPassword;
     }
 
-    public String generateAuthUrl() {
+    public String generateAuthUrl(String redirectUrl) {
         Map<String, String> params = new HashMap<>();
         params.put("scope", scope);
         params.put("response_type", "code");

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/OauthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/OauthControllerTest.java
@@ -66,7 +66,7 @@ class OauthControllerTest {
     @Test
     void login() throws Exception {
         String accessToken = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNjU5OTI3MTMxLCJleHAiOjE2NTk5MzA3MzF9.VG8BIv3X1peT0e16OdSqq4EkkgDd1bHbYX99oglxkS4";
-        BDDMockito.given(oauthService.requestAccessToken(ArgumentMatchers.anyString()))
+        BDDMockito.given(oauthService.requestAccessToken(ArgumentMatchers.anyString(), ArgumentMatchers.anyString()))
                 .willReturn(new LoginResponse(accessToken));
 
         String code = "code";

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/OauthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/OauthControllerTest.java
@@ -47,7 +47,7 @@ class OauthControllerTest {
     @Test
     void access() throws Exception {
         String oauthLink = "https://accounts.google.com/o/oauth2/auth?scope=openid%20https://www.googleapis.com/auth/userinfo.email%20https://www.googleapis.com/auth/userinfo.profile&response_type=code&redirect_uri=http://localhost:8080/api/auth/oauth2/google/login&client_id=clientId";
-        BDDMockito.given(oauthService.generateAuthUrl())
+        BDDMockito.given(oauthService.generateAuthUrl(ArgumentMatchers.anyString()))
                 .willReturn(new OauthLinkResponse(oauthLink));
 
         mockMvc.perform(get("/api/auth/oauth2/google/login"))


### PR DESCRIPTION
## 구현 기능
Oauth 인증 Redirect Uri 생성방식을 반응형으로 수정

* Oauth 인증에 관하여, 프론트 측과 협의한 내용은 다음 Issue에 적어두었습니다
https://github.com/woowacourse-teams/2022-momo/issues/234


## 코드 변경 사항

* `@OauthRedirectUrl`이 추가되었습니다.
-> `OauthRedirectUrlResolver#resolveArgument`에서 API 접근자의 프로토콜과 Host를 파싱하여 Redirect URL을 생성합니다.
-> 해당 로직이 필요한 이유는 프론트측의 테스트환경을 보장하기 위함입니다.
-> 테스트를 위한 코드이다 보니.. 추후에 개발이 완료되면 제거할지도?? (open redirect 취약점의 가능성 존재)

* `@OauthRequestUrl`이 추가되었습니다.
-> 사용자로부터 code를 받은 후 구글에게 AccessToken을 요청하는 과정에서
     구글이 `사용자에게 code를 넘겨주면서 리다이렉트하는 주소`와 `code와 함께 AccessToken을 요구하는 요청에 담긴 redirect_rul`을 비교하나봅니다. (일치하지 않으면 redirect_uri_mismatch 뜨면서 계속 구글 요청 실패함..ㅂㄷㅂㄷ / 관련자료 찾아도 안나옴 / 추측임) 여튼, 해당 요청을 통과하기 위해 사용자의 Request Url을 파싱해서 구글 요청에 사용합니다.

## 번외

이번에도 로컬에서는 정상 동작하지만, 배포서버에서는 어떻게 동작할지 확신이 안 드네요ㅜ
더군다나 프론트 측의 로컬 환경도 고려해야 했어서, 더더욱 확신이 안서요
아마도 관련 이슈로 PR이 잦을 듯 하지만.. 부디 한방에 끝났으면 좋겠네요!!

~~변경 사항 쓰다보니, 게임 업데이트 이력쓰는 것 같네요(개발 코멘트)ㅋㅎㅎ~~

