### PR TITLE
[BE] 이미지 업로드 기능 구현 

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -138,3 +138,21 @@ include::{snippets}/findparticipants/http-request.adoc[]
 Response
 include::{snippets}/findparticipants/http-response.adoc[]
 
+== 이미지
+
+=== 이미지 업로드
+
+Request
+include::{snippets}/imageupload/http-request.adoc[]
+
+Response
+include::{snippets}/imageupload/http-response.adoc[]
+
+=== 이미지 불러오기
+
+Request
+include::{snippets}/imageload/http-request.adoc[]
+
+Response
+include::{snippets}/imageload/http-response.adoc[]
+

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
@@ -48,7 +48,8 @@ public enum ErrorCode {
     PARTICIPANT_WITHDRAW_DEADLINE(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_006", "모집이 마감된 모임입니다."),
     PARTICIPANT_WITHDRAW_EARLY_CLOSED(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_007", "조기종료된 모임입니다."),
 
-    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "FILE_ERROR_001", "저장할 수 없는 확장자입니다.")
+    FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST.value(), "FILE_ERROR_001", "저장할 수 없는 확장자입니다."),
+    FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "FILE_ERROR_002", "파일 입출력 에러입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     PARTICIPANT_WITHDRAW_NOT_PARTICIPANT(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_005", "모임의 참여자가 아닙니다."),
     PARTICIPANT_WITHDRAW_DEADLINE(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_006", "모집이 마감된 모임입니다."),
     PARTICIPANT_WITHDRAW_EARLY_CLOSED(HttpStatus.BAD_REQUEST.value(), "PARTICIPANT_ERROR_007", "조기종료된 모임입니다."),
+
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST.value(), "FILE_ERROR_001", "저장할 수 없는 확장자입니다.")
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
@@ -40,5 +40,4 @@ public class ImageController {
 
         return ResponseEntity.ok(imageBytes);
     }
-
 }

--- a/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
@@ -28,7 +28,7 @@ public class ImageController {
     public ResponseEntity<Void> imageUpload(@RequestParam("imageFile") MultipartFile imageFile) {
         String fileName = storageService.save(imageFile);
 
-        return ResponseEntity.created(URI.create("/api/images/" + fileName)).build(); // filename 받아온다면 수정 필요
+        return ResponseEntity.created(URI.create("/api/images/" + fileName)).build();
     }
 
     @GetMapping(

--- a/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
@@ -13,12 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.storage.service.StorageService;
 
 @RestController
 @RequestMapping("/api/images/")
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class ImageController {
 
     private final StorageService storageService;

--- a/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
@@ -1,0 +1,43 @@
+package com.woowacourse.momo.storage.controller;
+
+import java.net.URI;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.AllArgsConstructor;
+
+import com.woowacourse.momo.storage.service.StorageService;
+
+@RestController
+@RequestMapping("/api/file/")
+@AllArgsConstructor
+public class ImageController {
+
+    private final StorageService storageService;
+
+    @PostMapping
+    public ResponseEntity<Void> imageUpload(@RequestParam("imageFile") MultipartFile imageFile) {
+        String fileName = storageService.save(imageFile);
+
+        return ResponseEntity.created(URI.create("/api/file/" + fileName)).build(); // filename 받아온다면 수정 필요
+    }
+
+    @GetMapping(
+            value = "{imageFileName}",
+            produces = { MediaType.IMAGE_GIF_VALUE, MediaType.IMAGE_JPEG_VALUE, MediaType.IMAGE_PNG_VALUE }
+    )
+    public ResponseEntity<byte[]> serveImage(@PathVariable String imageFileName) {
+        byte[] imageBytes = storageService.load(imageFileName);
+
+        return ResponseEntity.ok(imageBytes);
+    }
+
+}

--- a/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
@@ -17,7 +17,7 @@ import lombok.AllArgsConstructor;
 import com.woowacourse.momo.storage.service.StorageService;
 
 @RestController
-@RequestMapping("/api/file/")
+@RequestMapping("/api/images/")
 @AllArgsConstructor
 public class ImageController {
 
@@ -27,7 +27,7 @@ public class ImageController {
     public ResponseEntity<Void> imageUpload(@RequestParam("imageFile") MultipartFile imageFile) {
         String fileName = storageService.save(imageFile);
 
-        return ResponseEntity.created(URI.create("/api/file/" + fileName)).build(); // filename 받아온다면 수정 필요
+        return ResponseEntity.created(URI.create("/api/images/" + fileName)).build(); // filename 받아온다면 수정 필요
     }
 
     @GetMapping(

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -1,0 +1,57 @@
+package com.woowacourse.momo.storage.service;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class StorageService {
+
+    private static final String PATH_PREFIX = "./image-save/";
+
+    public String save(MultipartFile file) {
+        File temporary = new File(PATH_PREFIX + file.getOriginalFilename());
+        File directory = new File(PATH_PREFIX);
+
+        fileInit(temporary, directory);
+
+        try (OutputStream outputStream = new FileOutputStream(temporary)) {
+            outputStream.write(file.getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return temporary.getName();
+    }
+
+    private void fileInit(File temporary, File directory) {
+        try {
+            if (!directory.exists()) {
+                directory.mkdirs();
+            }
+            temporary.createNewFile();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public byte[] load(String fileName) {
+        File file = new File(PATH_PREFIX + fileName);
+        try (InputStream inputStream = new FileInputStream(file)) {
+            return inputStream.readAllBytes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -30,7 +30,7 @@ public class StorageService {
         try (OutputStream outputStream = new FileOutputStream(savedFile)) {
             outputStream.write(requestFile.getBytes());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MomoException(ErrorCode.FILE_IO_ERROR);
         }
 
         return savedFile.getName();
@@ -42,7 +42,7 @@ public class StorageService {
         if (contentType == null || !(contentType.equals(MediaType.IMAGE_GIF_VALUE) ||
                 contentType.equals(MediaType.IMAGE_JPEG_VALUE) ||
                 contentType.equals(MediaType.IMAGE_PNG_VALUE))) {
-            throw new MomoException(ErrorCode.INVALID_FILE_EXTENSION);
+            throw new MomoException(ErrorCode.FILE_INVALID_EXTENSION);
         }
     }
 
@@ -53,7 +53,7 @@ public class StorageService {
             }
             temporary.createNewFile();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MomoException(ErrorCode.FILE_IO_ERROR);
         }
     }
 
@@ -62,7 +62,7 @@ public class StorageService {
         try (InputStream inputStream = new FileInputStream(file)) {
             return inputStream.readAllBytes();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new MomoException(ErrorCode.FILE_IO_ERROR);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -2,18 +2,17 @@ package com.woowacourse.momo.storage.service;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
+import com.woowacourse.momo.globalException.exception.ErrorCode;
+import com.woowacourse.momo.globalException.exception.MomoException;
 
 @Service
 public class StorageService {
@@ -26,6 +25,8 @@ public class StorageService {
 
         fileInit(temporary, directory);
 
+        validateExtension(file);
+
         try (OutputStream outputStream = new FileOutputStream(temporary)) {
             outputStream.write(file.getBytes());
         } catch (IOException e) {
@@ -33,6 +34,16 @@ public class StorageService {
         }
 
         return temporary.getName();
+    }
+
+    private void validateExtension(MultipartFile file) {
+        String contentType = file.getContentType();
+
+        if (contentType == null || !(contentType.equals(MediaType.IMAGE_GIF_VALUE) ||
+                contentType.equals(MediaType.IMAGE_JPEG_VALUE) ||
+                contentType.equals(MediaType.IMAGE_PNG_VALUE))) {
+            throw new MomoException(ErrorCode.INVALID_FILE_EXTENSION);
+        }
     }
 
     private void fileInit(File temporary, File directory) {

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -19,21 +19,21 @@ public class StorageService {
 
     private static final String PATH_PREFIX = "./image-save/";
 
-    public String save(MultipartFile file) {
-        File temporary = new File(PATH_PREFIX + file.getOriginalFilename());
+    public String save(MultipartFile requestFile) {
+        File savedFile = new File(PATH_PREFIX + requestFile.getOriginalFilename());
         File directory = new File(PATH_PREFIX);
 
-        fileInit(temporary, directory);
+        fileInit(savedFile, directory);
 
-        validateExtension(file);
+        validateExtension(requestFile);
 
-        try (OutputStream outputStream = new FileOutputStream(temporary)) {
-            outputStream.write(file.getBytes());
+        try (OutputStream outputStream = new FileOutputStream(savedFile)) {
+            outputStream.write(requestFile.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
 
-        return temporary.getName();
+        return savedFile.getName();
     }
 
     private void validateExtension(MultipartFile file) {

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -1,6 +1,5 @@
 package com.woowacourse.momo.storage.controller;
 
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -45,11 +44,11 @@ public class ImageControllerTest {
         MockMultipartFile file = new MockMultipartFile(
                 "imageFile",
                 "abc.png",
-                MediaType.TEXT_PLAIN_VALUE,
+                MediaType.IMAGE_PNG_VALUE,
                 "abcdefgh".getBytes()
         );
 
-        this.mockMvc.perform(multipart("/api/images/").file(file))
+        mockMvc.perform(multipart("/api/images/").file(file))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(header().string("Location", "/api/images/abc.png"))
                 .andDo(
@@ -65,7 +64,7 @@ public class ImageControllerTest {
     void imageLoadTest() throws Exception {
         when(storageService.load("abc.png")).thenReturn("abcdefgh".getBytes());
 
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/api/images/abc.png"))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/images/abc.png"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().bytes("abcdefgh".getBytes()))
                 .andDo(

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -27,6 +28,7 @@ import com.woowacourse.momo.storage.service.StorageService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureRestDocs
 public class ImageControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -1,0 +1,63 @@
+package com.woowacourse.momo.storage.controller;
+
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.woowacourse.momo.storage.service.StorageService;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ImageControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    private StorageService storageService;
+
+    @Test
+    void imageUploadTest() throws Exception {
+        when(storageService.save(any())).thenReturn("abc.txt");
+
+        MockMultipartFile file = new MockMultipartFile(
+                "imageFile",
+                "abc.txt",
+                MediaType.TEXT_PLAIN_VALUE,
+                "abcdefgh".getBytes()
+        );
+
+        this.mockMvc.perform(multipart("/api/file/").file(file))
+                        .andExpect(status().is2xxSuccessful())
+                        .andExpect(header().string("Location", "/api/file/abc.txt"));
+    }
+
+    @Test
+    void imageLoadTest() throws Exception {
+        when(storageService.load("abc.txt")).thenReturn("abcdefgh".getBytes());
+
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/api/file/abc.txt"))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(content().bytes("abcdefgh".getBytes()));
+    }
+
+}

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -1,17 +1,16 @@
 package com.woowacourse.momo.storage.controller;
 
 
-
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-
-import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,8 +48,14 @@ public class ImageControllerTest {
         );
 
         this.mockMvc.perform(multipart("/api/file/").file(file))
-                        .andExpect(status().is2xxSuccessful())
-                        .andExpect(header().string("Location", "/api/file/abc.txt"));
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(header().string("Location", "/api/file/abc.txt"))
+                .andDo(
+                        document("imageupload",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint())
+                        )
+                );
     }
 
     @DisplayName("이미지를 불러온다")
@@ -60,7 +65,13 @@ public class ImageControllerTest {
 
         this.mockMvc.perform(MockMvcRequestBuilders.get("/api/file/abc.txt"))
                 .andExpect(status().is2xxSuccessful())
-                .andExpect(content().bytes("abcdefgh".getBytes()));
+                .andExpect(content().bytes("abcdefgh".getBytes()))
+                .andDo(
+                        document("imageload",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint())
+                        )
+                );
     }
 
 }

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -75,5 +75,4 @@ public class ImageControllerTest {
                         )
                 );
     }
-
 }

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -49,9 +49,9 @@ public class ImageControllerTest {
                 "abcdefgh".getBytes()
         );
 
-        this.mockMvc.perform(multipart("/api/file/").file(file))
+        this.mockMvc.perform(multipart("/api/images/").file(file))
                 .andExpect(status().is2xxSuccessful())
-                .andExpect(header().string("Location", "/api/file/abc.txt"))
+                .andExpect(header().string("Location", "/api/images/abc.txt"))
                 .andDo(
                         document("imageupload",
                                 preprocessRequest(prettyPrint()),
@@ -65,7 +65,7 @@ public class ImageControllerTest {
     void imageLoadTest() throws Exception {
         when(storageService.load("abc.txt")).thenReturn("abcdefgh".getBytes());
 
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/api/file/abc.txt"))
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/api/images/abc.txt"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().bytes("abcdefgh".getBytes()))
                 .andDo(

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.nio.charset.StandardCharsets;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -35,6 +36,7 @@ public class ImageControllerTest {
     @MockBean
     private StorageService storageService;
 
+    @DisplayName("이미지를 업로드한다")
     @Test
     void imageUploadTest() throws Exception {
         when(storageService.save(any())).thenReturn("abc.txt");
@@ -51,6 +53,7 @@ public class ImageControllerTest {
                         .andExpect(header().string("Location", "/api/file/abc.txt"));
     }
 
+    @DisplayName("이미지를 불러온다")
     @Test
     void imageLoadTest() throws Exception {
         when(storageService.load("abc.txt")).thenReturn("abcdefgh".getBytes());

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -40,18 +40,18 @@ public class ImageControllerTest {
     @DisplayName("이미지를 업로드한다")
     @Test
     void imageUploadTest() throws Exception {
-        when(storageService.save(any())).thenReturn("abc.txt");
+        when(storageService.save(any())).thenReturn("abc.png");
 
         MockMultipartFile file = new MockMultipartFile(
                 "imageFile",
-                "abc.txt",
+                "abc.png",
                 MediaType.TEXT_PLAIN_VALUE,
                 "abcdefgh".getBytes()
         );
 
         this.mockMvc.perform(multipart("/api/images/").file(file))
                 .andExpect(status().is2xxSuccessful())
-                .andExpect(header().string("Location", "/api/images/abc.txt"))
+                .andExpect(header().string("Location", "/api/images/abc.png"))
                 .andDo(
                         document("imageupload",
                                 preprocessRequest(prettyPrint()),
@@ -63,9 +63,9 @@ public class ImageControllerTest {
     @DisplayName("이미지를 불러온다")
     @Test
     void imageLoadTest() throws Exception {
-        when(storageService.load("abc.txt")).thenReturn("abcdefgh".getBytes());
+        when(storageService.load("abc.png")).thenReturn("abcdefgh".getBytes());
 
-        this.mockMvc.perform(MockMvcRequestBuilders.get("/api/images/abc.txt"))
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/api/images/abc.png"))
                 .andExpect(status().is2xxSuccessful())
                 .andExpect(content().bytes("abcdefgh".getBytes()))
                 .andDo(


### PR DESCRIPTION

- #224 

이미지 업로드 기능을 구현하였습니다~ 경로는 `./image-save/`로 설정해 두었습니다!
테스트의 경우는.. 실제 로컬에 저장해서 테스트하는 것은 좋지 않다고 판단되어 컨트롤러 테스트만 작성해 두었으며 서비스 부분을 MockBean으로 등록 후 모킹하여 처리하였습니다.

약간 혼란스러운 부분은 api의 path를 `/api/images/{image_name}`으로 하는 것 보다는.. 정적 리소스에 대한 접근이라고 보는게 더 맞지 않나 싶어 `/images/{image_name}`이 맞지 않나 싶습니다~