### PR TITLE
[BE] OAuth 로그인기능 실패 오류 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -38,6 +39,7 @@ public class OauthService {
         return new OauthLinkResponse(oauthLink);
     }
 
+    @Transactional
     public LoginResponse requestAccessToken(String code, String redirectUrl) {
         GoogleUserResponse response = requestUserInfo(code, redirectUrl);
 


### PR DESCRIPTION
# Issue
- #247 

# Problem
이전에 기본 로그인에 대해서 리프레시 토큰을 저장하는 DB에는 Transactional을 붙였었는데 OAuth에 붙이는 것을 빼먹었네요..
바로 추가했습니다