### PR TITLE
[BE] SonarQube 서버 구축 및 Github Actions PR 연동

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,12 +28,48 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: 11
           distribution: 'adopt'
           cache: gradle
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Build
         run: ./gradlew build
+
+  sonarqube:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.SECURITY_TOKEN }}
+          submodules: recursive
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'adopt'
+          cache: gradle
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: ./gradlew build sonarqube --info

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,8 +1,9 @@
 plugins {
+	id 'java'
 	id 'org.springframework.boot' version '2.6.9'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-	id 'java'
 	id "org.asciidoctor.jvm.convert" version "3.3.2"
+	id "org.sonarqube" version "3.4.0.2513"
 }
 
 group = 'com.woowacourse'
@@ -75,5 +76,11 @@ bootJar {
 	copy {
 		from file("src/main/resources/static")
 		into file("build/resources/main/static")
+	}
+}
+
+sonarqube {
+	properties {
+		property "sonar.projectKey", "woowacourse-teams_2022-momo_AYKR-JWB6L96jeu46QtV"
 	}
 }


### PR DESCRIPTION
#  🌟 구현 기능
- [x] SonarQube 서버 구축
- [x] Github Actions을 통해 PR의 코멘트로 정적분석 리포트 제공


### Issue
- https://github.com/woowacourse-teams/2022-momo/issues/259