### PR TITLE
[BE] Code Smell 제거

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/MomoApplication.java
+++ b/backend/src/main/java/com/woowacourse/momo/MomoApplication.java
@@ -9,5 +9,4 @@ public class MomoApplication {
     public static void main(String[] args) {
         SpringApplication.run(MomoApplication.class, args);
     }
-
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -41,7 +41,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private void validateToken(HttpServletRequest request) {
         String token = AuthorizationExtractor.extract(request);
-        if (!jwtTokenProvider.validateToken(token)) {
+        if (jwtTokenProvider.validateTokenNotUsable(token)) {
             throw new MomoException(ErrorCode.AUTH_INVALID_TOKEN);
         }
     }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -12,7 +12,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import lombok.RequiredArgsConstructor;
 
-import com.woowacourse.momo.auth.exception.AuthFailException;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
 import com.woowacourse.momo.globalException.exception.ErrorCode;

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -14,8 +14,8 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
@@ -23,7 +23,7 @@ public class RefreshTokenAuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String refreshToken = AuthorizationExtractor.extract(request);
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
+        if (jwtTokenProvider.validateTokenNotUsable(refreshToken)) {
             throw new MomoException(ErrorCode.AUTH_INVALID_TOKEN);
         }
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
@@ -11,8 +11,8 @@ import com.woowacourse.momo.auth.domain.Token;
 import com.woowacourse.momo.auth.domain.TokenRepository;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @RequiredArgsConstructor
 public class RefreshTokenAuthInterceptor implements HandlerInterceptor {

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
@@ -13,8 +13,8 @@ import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
@@ -1,7 +1,7 @@
 package com.woowacourse.momo.auth.service;
 
-import static com.woowacourse.momo.globalException.exception.ErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS;
-import static com.woowacourse.momo.globalException.exception.ErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY;
+import static com.woowacourse.momo.global.exception.exception.ErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS;
+import static com.woowacourse.momo.global.exception.exception.ErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY;
 
 import java.util.Optional;
 
@@ -19,7 +19,7 @@ import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.auth.support.google.GoogleConnector;
 import com.woowacourse.momo.auth.support.google.GoogleProvider;
 import com.woowacourse.momo.auth.support.google.dto.GoogleUserResponse;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -4,7 +4,6 @@ import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 
-import com.woowacourse.momo.auth.exception.AuthFailException;
 import com.woowacourse.momo.globalException.exception.ErrorCode;
 import com.woowacourse.momo.globalException.exception.MomoException;
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -4,14 +4,18 @@ import java.util.Enumeration;
 
 import javax.servlet.http.HttpServletRequest;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import com.woowacourse.momo.globalException.exception.ErrorCode;
 import com.woowacourse.momo.globalException.exception.MomoException;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthorizationExtractor {
 
-    public static final String AUTHORIZATION = "Authorization";
-    public static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
-    public static String BEARER_TYPE = "Bearer";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
+    private static final String BEARER_TYPE = "Bearer";
 
     public static String extract(HttpServletRequest request) {
         Enumeration<String> headers = request.getHeaders(AUTHORIZATION);

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -7,8 +7,8 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthorizationExtractor {

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
@@ -60,15 +60,15 @@ public class JwtTokenProvider {
                 getClaims(token).getBody().getSubject());
     }
 
-    public boolean validateToken(String token) {
+    public boolean validateTokenNotUsable(String token) {
         try {
             Jws<Claims> claims = getClaims(token);
 
-            return !claims.getBody().getExpiration().before(new Date());
+            return claims.getBody().getExpiration().before(new Date());
         } catch (ExpiredJwtException e) {
             throw new MomoException(ErrorCode.AUTH_EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
-            return false;
+            return true;
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
@@ -16,8 +16,8 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Component
 public class JwtTokenProvider {

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
@@ -42,10 +42,10 @@ public class JwtTokenProvider {
         return createToken(payload, refreshTokenValidityInMilliseconds);
     }
 
-    private String createToken(Long payload, long ValidityInMilliseconds) {
+    private String createToken(Long payload, long validityInMilliseconds) {
         Claims claims = Jwts.claims().setSubject(Long.toString(payload));
         Date now = new Date();
-        Date validity = new Date(now.getTime() + ValidityInMilliseconds);
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
 
         return Jwts.builder()
                 .setClaims(claims)

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
@@ -1,7 +1,7 @@
 package com.woowacourse.momo.auth.support.google;
 
-import static com.woowacourse.momo.globalException.exception.ErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_2XX_STATUS;
-import static com.woowacourse.momo.globalException.exception.ErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY;
+import static com.woowacourse.momo.global.exception.exception.ErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_2XX_STATUS;
+import static com.woowacourse.momo.global.exception.exception.ErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.support.google.dto.GoogleTokenResponse;
 import com.woowacourse.momo.auth.support.google.dto.GoogleUserResponse;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Getter
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/global/config/AspectConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/AspectConfiguration.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.config;
+package com.woowacourse.momo.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -6,9 +6,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
-import com.woowacourse.momo.logging.ExceptionLogging;
-import com.woowacourse.momo.logging.LogFileManager;
-import com.woowacourse.momo.logging.Logging;
+import com.woowacourse.momo.global.logging.ExceptionLogging;
+import com.woowacourse.momo.global.logging.LogFileManager;
+import com.woowacourse.momo.global.logging.Logging;
 
 @Configuration
 @EnableAspectJAutoProxy

--- a/backend/src/main/java/com/woowacourse/momo/global/config/CustomNamingStrategy.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/CustomNamingStrategy.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.config;
+package com.woowacourse.momo.global.config;
 
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;

--- a/backend/src/main/java/com/woowacourse/momo/global/config/GlobalWebConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/GlobalWebConfiguration.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.config;
+package com.woowacourse.momo.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
@@ -1,13 +1,13 @@
-package com.woowacourse.momo.globalException;
+package com.woowacourse.momo.global.exception;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.woowacourse.momo.globalException.dto.response.ExceptionResponse;
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.dto.response.ExceptionResponse;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @RestControllerAdvice
 public class ControllerAdvice {

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/dto/response/ExceptionResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/dto/response/ExceptionResponse.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.globalException.dto.response;
+package com.woowacourse.momo.global.exception.dto.response;
 
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.globalException.exception;
+package com.woowacourse.momo.global.exception.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/MomoException.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/MomoException.java
@@ -1,13 +1,13 @@
-package com.woowacourse.momo.globalException.exception;
+package com.woowacourse.momo.global.exception.exception;
 
 import lombok.Getter;
 
 @Getter
 public class MomoException extends RuntimeException {
 
-    int statusCode;
-    String errorCode;
-    String message;
+    private final int statusCode;
+    private final String errorCode;
+    private final String message;
 
     public MomoException(ErrorCode code) {
         statusCode = code.getStatusCode();

--- a/backend/src/main/java/com/woowacourse/momo/global/logging/ConsolePrettier.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/logging/ConsolePrettier.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.logging;
+package com.woowacourse.momo.global.logging;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/backend/src/main/java/com/woowacourse/momo/global/logging/ExceptionLogging.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/logging/ExceptionLogging.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.logging;
+package com.woowacourse.momo.global.logging;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -19,7 +19,7 @@ public class ExceptionLogging {
     public void allMethod() {
     }
 
-    @Pointcut("execution(* com.woowacourse.momo.globalException.ControllerAdvice.handleAnyException(..))")
+    @Pointcut("execution(* com.woowacourse.momo.global.exception.ControllerAdvice.handleAnyException(..))")
     public void exceptionMethod() {
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/global/logging/LogFileManager.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/logging/LogFileManager.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.logging;
+package com.woowacourse.momo.global.logging;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import com.woowacourse.momo.logging.exception.LogException;
+import com.woowacourse.momo.global.logging.exception.LogException;
 
 public class LogFileManager {
 

--- a/backend/src/main/java/com/woowacourse/momo/global/logging/Logging.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/logging/Logging.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.logging;
+package com.woowacourse.momo.global.logging;
 
 import java.util.Arrays;
 

--- a/backend/src/main/java/com/woowacourse/momo/global/logging/exception/LogException.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/logging/exception/LogException.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.logging.exception;
+package com.woowacourse.momo.global.logging.exception;
 
 public class LogException extends RuntimeException {
 

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/ErrorCode.java
@@ -55,5 +55,4 @@ public enum ErrorCode {
     private final int statusCode;
     private final String errorCode;
     private final String message;
-
 }

--- a/backend/src/main/java/com/woowacourse/momo/globalException/exception/MomoException.java
+++ b/backend/src/main/java/com/woowacourse/momo/globalException/exception/MomoException.java
@@ -14,5 +14,4 @@ public class MomoException extends RuntimeException {
         errorCode = code.getErrorCode();
         message = code.getMessage();
     }
-
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
@@ -10,8 +10,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/duration/Duration.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.globalException.exception.ErrorCode;
 import com.woowacourse.momo.globalException.exception.MomoException;
-import com.woowacourse.momo.group.exception.InvalidDurationException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/group/Group.java
@@ -26,8 +26,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.category.domain.Category;
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.duration.Duration;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
 import com.woowacourse.momo.member.domain.Member;

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
@@ -48,7 +48,7 @@ public class Schedule {
     }
 
     public boolean checkInRange(LocalDate startDate, LocalDate endDate) {
-        return (date.isAfter(startDate) | date.isEqual(startDate))
-                && (date.isBefore(endDate) | date.isEqual(endDate));
+        return (date.isAfter(startDate) || date.isEqual(startDate))
+                && (date.isBefore(endDate) || date.isEqual(endDate));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/schedule/Schedule.java
@@ -13,8 +13,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
@@ -14,7 +14,6 @@ import com.woowacourse.momo.globalException.exception.ErrorCode;
 import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
-import com.woowacourse.momo.group.exception.NotFoundGroupException;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
@@ -10,8 +10,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
 

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -81,10 +81,14 @@ public class GroupService {
     }
 
     private void validateSchedulesInDuration(List<Schedule> schedules, Duration duration) {
-        schedules.stream()
-                .filter(schedule -> !schedule.checkInRange(duration.getStartDate(), duration.getEndDate()))
-                .findAny()
-                .ifPresent(schedule -> { throw new MomoException(ErrorCode.GROUP_SCHEDULE_NOT_RANGE_DURATION); } );
+        if (existAnyScheduleOutOfDuration(schedules, duration)) {
+            throw new MomoException(ErrorCode.GROUP_SCHEDULE_NOT_RANGE_DURATION);
+        }
+    }
+
+    private boolean existAnyScheduleOutOfDuration(List<Schedule> schedules, Duration duration) {
+        return schedules.stream()
+                .anyMatch(schedule -> !schedule.checkInRange(duration.getStartDate(), duration.getEndDate()));
     }
 
     @Transactional

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.category.domain.Category;
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.duration.Duration;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
@@ -5,8 +5,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
@@ -9,7 +9,6 @@ import com.woowacourse.momo.globalException.exception.ErrorCode;
 import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
-import com.woowacourse.momo.member.exception.NotFoundMemberException;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/controller/ImageController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.storage.service.StorageService;

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -1,13 +1,17 @@
 package com.woowacourse.momo.storage.service;
 
+import static org.springframework.http.MediaType.IMAGE_GIF_VALUE;
+import static org.springframework.http.MediaType.IMAGE_JPEG_VALUE;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,12 +22,13 @@ import com.woowacourse.momo.global.exception.exception.MomoException;
 public class StorageService {
 
     private static final String PATH_PREFIX = "./image-save/";
+    private static final List<String> IMAGE_CONTENT_TYPES = List.of(IMAGE_GIF_VALUE, IMAGE_JPEG_VALUE, IMAGE_PNG_VALUE);
 
     public String save(MultipartFile requestFile) {
+        validateContentType(requestFile);
+
         File savedFile = new File(PATH_PREFIX + requestFile.getOriginalFilename());
         File directory = new File(PATH_PREFIX);
-
-        validateExtension(requestFile);
 
         fileInit(savedFile, directory);
 
@@ -36,14 +41,17 @@ public class StorageService {
         return savedFile.getName();
     }
 
-    private void validateExtension(MultipartFile file) {
+    private void validateContentType(MultipartFile file) {
         String contentType = file.getContentType();
 
-        if (contentType == null || !(contentType.equals(MediaType.IMAGE_GIF_VALUE) ||
-                contentType.equals(MediaType.IMAGE_JPEG_VALUE) ||
-                contentType.equals(MediaType.IMAGE_PNG_VALUE))) {
+        if (contentType == null || isContentTypeNotImage(contentType)) {
             throw new MomoException(ErrorCode.FILE_INVALID_EXTENSION);
         }
+    }
+
+    private boolean isContentTypeNotImage(String contentType) {
+        return IMAGE_CONTENT_TYPES.stream()
+                .noneMatch(contentType::equals);
     }
 
     private void fileInit(File temporary, File directory) {

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -11,8 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.woowacourse.momo.globalException.exception.ErrorCode;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Service
 public class StorageService {

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -23,9 +23,9 @@ public class StorageService {
         File savedFile = new File(PATH_PREFIX + requestFile.getOriginalFilename());
         File directory = new File(PATH_PREFIX);
 
-        fileInit(savedFile, directory);
-
         validateExtension(requestFile);
+
+        fileInit(savedFile, directory);
 
         try (OutputStream outputStream = new FileOutputStream(savedFile)) {
             outputStream.write(requestFile.getBytes());

--- a/backend/src/main/resources/application-datasource.yml
+++ b/backend/src/main/resources/application-datasource.yml
@@ -1,4 +1,4 @@
 spring:
   jpa:
     hibernate:
-      naming.physical-strategy: com.woowacourse.momo.config.CustomNamingStrategy
+      naming.physical-strategy: com.woowacourse.momo.global.config.CustomNamingStrategy

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/auth/AuthAcceptanceTest.java
@@ -14,7 +14,7 @@ import com.woowacourse.momo.acceptance.AcceptanceTest;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.fixture.MemberFixture;
 
-public class AuthAcceptanceTest extends AcceptanceTest {
+class AuthAcceptanceTest extends AcceptanceTest {
 
     private static final MemberFixture MEMBER_FIXTURE = MemberFixture.MOMO;
 

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
@@ -1,12 +1,12 @@
 package com.woowacourse.momo.acceptance.group;
 
-import static com.woowacourse.momo.acceptance.participant.ParticipantRestHandler.모임에_참여한다;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import static com.woowacourse.momo.acceptance.group.GroupRestHandler.모임을_수정한다;
 import static com.woowacourse.momo.acceptance.group.GroupRestHandler.모임을_조기마감한다;
+import static com.woowacourse.momo.acceptance.participant.ParticipantRestHandler.모임에_참여한다;
 import static com.woowacourse.momo.fixture.GroupFixture.DUDU_STUDY;
 import static com.woowacourse.momo.fixture.MemberFixture.DUDU;
 

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/member/MemberAcceptanceTest.java
@@ -11,7 +11,7 @@ import com.woowacourse.momo.acceptance.AcceptanceTest;
 import com.woowacourse.momo.acceptance.auth.AuthRestHandler;
 import com.woowacourse.momo.fixture.MemberFixture;
 
-public class MemberAcceptanceTest extends AcceptanceTest {
+class MemberAcceptanceTest extends AcceptanceTest {
 
     private static final MemberFixture MEMBER = MemberFixture.MOMO;
 

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/OauthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/OauthControllerTest.java
@@ -5,11 +5,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.JsonFieldType.STRING;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
@@ -18,7 +18,7 @@ import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.service.MemberFindService;
 

--- a/backend/src/test/java/com/woowacourse/momo/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/category/controller/CategoryControllerTest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @SpringBootTest
-public class CategoryControllerTest {
+class CategoryControllerTest {
 
     @Autowired
     MockMvc mockMvc;

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
@@ -13,7 +13,7 @@ import static com.woowacourse.momo.fixture.DateTimeFixture.이틀후_23시_59분
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 class DurationTest {
 

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/duration/DurationTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.woowacourse.momo.globalException.exception.MomoException;
-import com.woowacourse.momo.group.exception.InvalidDurationException;
 
 class DurationTest {
 

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/group/GroupTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.woowacourse.momo.category.domain.Category;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.schedule.Schedule;
 import com.woowacourse.momo.member.domain.Member;
 

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/schedule/ScheduleTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/schedule/ScheduleTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 
 class ScheduleTest {
 

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupFindServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupFindServiceTest.java
@@ -25,7 +25,7 @@ import com.woowacourse.momo.member.domain.MemberRepository;
 
 @Transactional
 @SpringBootTest
-public class GroupFindServiceTest {
+class GroupFindServiceTest {
 
     @Autowired
     private GroupFindService groupFindService;

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupServiceTest.java
@@ -24,7 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.category.domain.Category;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
 import com.woowacourse.momo.group.service.dto.request.DurationRequest;

--- a/backend/src/test/java/com/woowacourse/momo/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/controller/MemberControllerTest.java
@@ -35,7 +35,7 @@ import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
 @AutoConfigureRestDocs
 @Transactional
 @SpringBootTest
-public class MemberControllerTest {
+class MemberControllerTest {
 
     private static final String ID = "momo";
     private static final String PASSWORD = "1q2W3e4r!";

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -15,7 +15,6 @@ import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.globalException.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
-import com.woowacourse.momo.member.exception.NotFoundMemberException;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
 import com.woowacourse.momo.member.service.dto.response.MyInfoResponse;

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;

--- a/backend/src/test/java/com/woowacourse/momo/participant/controller/ParticipantControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/controller/ParticipantControllerTest.java
@@ -45,7 +45,7 @@ import com.woowacourse.momo.participant.service.ParticipantService;
 @AutoConfigureRestDocs
 @Transactional
 @SpringBootTest
-public class ParticipantControllerTest {
+class ParticipantControllerTest {
 
     private static final DurationRequest DURATION_REQUEST = new DurationRequest(이틀후.getInstance(),
             이틀후.getInstance());

--- a/backend/src/test/java/com/woowacourse/momo/participant/domain/ParticipantRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/domain/ParticipantRepositoryTest.java
@@ -1,9 +1,10 @@
 package com.woowacourse.momo.participant.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import static com.woowacourse.momo.fixture.DateTimeFixture.내일_23시_59분;
 import static com.woowacourse.momo.fixture.DurationFixture.이틀후부터_일주일후까지;
 import static com.woowacourse.momo.fixture.ScheduleFixture.이틀후_10시부터_12시까지;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Optional;

--- a/backend/src/test/java/com/woowacourse/momo/participant/service/ParticipantServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/participant/service/ParticipantServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import com.woowacourse.momo.category.domain.Category;
-import com.woowacourse.momo.globalException.exception.MomoException;
+import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.group.Group;
 import com.woowacourse.momo.group.domain.group.GroupRepository;
 import com.woowacourse.momo.group.service.GroupService;

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/ImageControllerTest.java
@@ -28,7 +28,7 @@ import com.woowacourse.momo.storage.service.StorageService;
 @SpringBootTest
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
-public class ImageControllerTest {
+class ImageControllerTest {
 
     @Autowired
     MockMvc mockMvc;


### PR DESCRIPTION
#  🌟 진행 사항
코드 스멜 제거
[View in SonarQube](http://3.35.47.159:8081/dashboard?id=woowacourse-teams_2022-momo_AYKR-JWB6L96jeu46QtV&pullRequest=261)


# 주요 변경 사항
- [x] globalException 패키지명 수정에 따른 global 패키지 생성 및 구조 변경

- [x] Schedule - 잘못된 연산자 사용 수정 ( | -> || )

- [x] GroupService#validateSchedulesInDuration 리팩터링

- [x] JwtTokenProvider - boolean 반환 메서드의 리턴값 전환 및 메서드명 변경 (validateToken -> validateTokenNotUsable)
  - 해당 메서드를 사용하는 로직이 모두 결과값을 반전(!연산자)하여 사용했음

- [x] StorageService - 검증 로직 리팩터링

- [x] AuthorizationExtractor - 빈 생성자(private) 추가 / 상수 private final 선언

- [x] 테스트 클래스의 public 접근제어자 제거

- [x] imports 최적화


## 번외

~SonarQube 서버가 꺼져있네요. 캠퍼스가서 켜도록 하겠슴다~ 서버 열었습니다