### PR TITLE
[BE] 회원 탈퇴 시 에러 발생

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/service/TokenService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/TokenService.java
@@ -16,6 +16,7 @@ public class TokenService {
 
     private final TokenRepository tokenRepository;
 
+    @Transactional
     public void synchronizeRefreshToken(Member member, String refreshToken) {
         tokenRepository.findByMemberId(member.getId())
                 .ifPresentOrElse(
@@ -24,7 +25,8 @@ public class TokenService {
                 );
     }
 
+    @Transactional
     public void deleteByMemberId(Long memberId) {
-        tokenRepository.findByMemberId(memberId);
+        tokenRepository.deleteByMemberId(memberId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/Member.java
@@ -56,7 +56,6 @@ public class Member {
     }
 
     public void delete() {
-        userId = GHOST_PRIVATE_INFO;
         password = GHOST_PRIVATE_INFO;
         name = GHOST_NAME;
         deleted = true;

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.domain.TokenRepository;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
@@ -29,6 +30,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final GroupFindService groupFindService;
     private final ParticipantRepository participantRepository;
+    private final TokenRepository tokenRepository;
 
     public MyInfoResponse findById(Long id) {
         Member member = memberFindService.findMember(id);
@@ -40,6 +42,7 @@ public class MemberService {
     public void deleteById(Long id) {
         Member member = memberFindService.findMember(id);
         leaveProgressingGroup(member);
+        tokenRepository.deleteByMemberId(member.getId());
         member.delete();
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/participant/controller/ParticipantController.java
+++ b/backend/src/main/java/com/woowacourse/momo/participant/controller/ParticipantController.java
@@ -36,6 +36,7 @@ public class ParticipantController {
         return ResponseEntity.ok(participantService.findParticipants(groupId));
     }
 
+    @Authenticated
     @DeleteMapping
     public ResponseEntity<Void> delete(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId) {
         participantService.delete(groupId, memberId);

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.woowacourse.momo.auth.domain.TokenRepository;
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
@@ -55,6 +56,9 @@ class MemberServiceTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private TokenRepository tokenRepository;
 
     private Member savedHost;
 
@@ -128,9 +132,12 @@ class MemberServiceTest {
 
         memberService.deleteById(memberId);
 
-        assertThatThrownBy(() -> memberService.findById(memberId))
-                .isInstanceOf(MomoException.class)
-                .hasMessage("탈퇴한 멤버입니다.");
+        assertAll(
+                () -> assertThat(tokenRepository.findByMemberId(memberId)).isEmpty(),
+                () -> assertThatThrownBy(() -> memberService.findById(memberId))
+                        .isInstanceOf(MomoException.class)
+                        .hasMessage("탈퇴한 멤버입니다.")
+        );
     }
 
     @DisplayName("회원 정보 삭제 시 참여한 모임 중 진행중인 모임이 있을 경우 모임에 탈퇴시킨다")


### PR DESCRIPTION
## ✨ Issue
- #307 

## 🐞 버그가 발생한 기능
두 번 이상 회원 탈퇴 요청 시 500 에러가 발생하였다. 원인은 회원 이름에 `unique` 제약 조건이 걸려 있는데 회원 탈퇴 시 빈값으로 수정하는 과정 때문에 동일한 이름이 존재하여 예외가 발생하였다. 

## 🧐 해결 방법
회원을 탈퇴하더라도 이름을 변경하지 않는다. 로직을 변경하면서 빠트린 토큰 삭제 과정도 추가하였다.