### PR TITLE
[FE] 배포 모드에서 favicon이 보이지 않는 오류 해결

### DIFF
--- a/frontend/webpack/webpack.common.js
+++ b/frontend/webpack/webpack.common.js
@@ -55,6 +55,7 @@ module.exports = {
     new CleanWebpackPlugin(),
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      favicon: './public/favicon.ico',
     }),
   ],
 };


### PR DESCRIPTION
## Issue

- #310

## Description (optional)

- 빌드 시 favicon이 포함되지 않음
  - 웹팩 설정에 favicon을 추가하여 빌드될 수 있도록 수정

closed #310 