### PR TITLE
[BE] 모임 참여인원이 실제와 다르게 출력되는 현상 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -72,7 +72,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
     private Page<Group> findGroups(SearchCondition condition, Pageable pageable,
                                    Supplier<BooleanExpression> mainCondition) {
         List<Group> groups = queryFactory
-                .selectFrom(group)
+                .select(group).distinct()
                 .leftJoin(group.participants.participants, participant)
                 .where(
                         mainCondition.get(),
@@ -88,7 +88,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
 
     public List<Group> findParticipatedGroups(Member member) {
         return queryFactory
-                .selectFrom(group)
+                .select(group).distinct()
                 .leftJoin(group.participants.participants, participant)
                 .where(isParticipated(member))
                 .fetch();

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -73,6 +73,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                                    Supplier<BooleanExpression> mainCondition) {
         List<Group> groups = queryFactory
                 .select(group).distinct()
+                .from(group)
                 .leftJoin(group.participants.participants, participant)
                 .where(
                         mainCondition.get(),
@@ -89,6 +90,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
     public List<Group> findParticipatedGroups(Member member) {
         return queryFactory
                 .select(group).distinct()
+                .from(group)
                 .leftJoin(group.participants.participants, participant)
                 .where(isParticipated(member))
                 .fetch();

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -74,7 +74,6 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
         List<Group> groups = queryFactory
                 .selectFrom(group)
                 .leftJoin(group.participants.participants, participant)
-                .fetchJoin()
                 .where(
                         mainCondition.get(),
                         conditionFilter.filterByCondition(condition)
@@ -91,7 +90,6 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
         return queryFactory
                 .selectFrom(group)
                 .leftJoin(group.participants.participants, participant)
-                .fetchJoin()
                 .where(isParticipated(member))
                 .fetch();
     }


### PR DESCRIPTION
## 해결 방법
fetchjoin을 사용하다 보니 조건을 만족하는 participants만 조회되는 문제가 발생한 것 같습니다.
 - 본인이 호스트인 경우 본인만 조회되므로 1명
 - 본인이 참여자인 경우 호스트인 사람 + 참여자에 본인 한명 = 2명

일단 fetchjoin을 풀고, leftjoin만 걸려있다 보니 중복 데이터가 나타나는 문제가 있어 distinct를 따로 걸어 두었습니다.