### PR TITLE
[BE] 마감일이 지나지 않아도 참여자 정원이 가득차면 수정/삭제할 수 없는 현상

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -123,7 +123,6 @@ public class Group {
 
     private void validateGroupIsUpdatable() {
         validateGroupIsProceeding();
-        //validateParticipantIsEmpty();
     }
 
     private void validateGroupIsProceeding() {
@@ -140,12 +139,6 @@ public class Group {
     private void validateDeadlineNotOver() {
         if (calendar.isDeadlineOver()) {
             throw new GroupException(ALREADY_DEADLINE_OVER);
-        }
-    }
-
-    private void validateParticipantIsEmpty() {
-        if (participants.isNotEmpty()) {
-            throw new GroupException(PARTICIPANT_EXIST);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -80,7 +80,7 @@ public class Group {
     }
 
     public void update(Capacity capacity, Calendar calendar, GroupName name, Category category, String description) {
-        validateGroupIsUpdatable();
+        validateGroupIsProceeding();
         this.participants.updateCapacity(capacity);
         this.calendar.update(calendar.getDeadline(), calendar.getDuration(), calendar.getSchedules());
         this.name = name;
@@ -117,15 +117,7 @@ public class Group {
         favorites.cancel(member);
     }
 
-    public void validateGroupIsDeletable() {
-        validateGroupIsUpdatable();
-    }
-
-    private void validateGroupIsUpdatable() {
-        validateGroupIsProceeding();
-    }
-
-    private void validateGroupIsProceeding() {
+    public void validateGroupIsProceeding() {
         validateGroupIsNotClosedEarly();
         validateDeadlineNotOver();
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -123,7 +123,7 @@ public class Group {
 
     private void validateGroupIsUpdatable() {
         validateGroupIsProceeding();
-        validateParticipantIsEmpty();
+        //validateParticipantIsEmpty();
     }
 
     private void validateGroupIsProceeding() {
@@ -158,7 +158,7 @@ public class Group {
     }
 
     public boolean isFinishedRecruitment() {
-        return closedEarly || calendar.isDeadlineOver() || participants.isFull();
+        return closedEarly || calendar.isDeadlineOver();
     }
 
     public Member getHost() {

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/ConditionFilter.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/ConditionFilter.java
@@ -30,8 +30,7 @@ public class ConditionFilter {
     private void excludeFinished(BooleanBuilder booleanBuilder, boolean excludeFinished) {
         if (excludeFinished) {
             booleanBuilder.and(afterNow()
-                    .and(notClosedEarly())
-                    .and(isNotParticipantsFull()));
+                    .and(notClosedEarly()));
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupModifyService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupModifyService.java
@@ -70,7 +70,7 @@ public class GroupModifyService {
     @Transactional
     public void delete(Long hostId, Long groupId) {
         ifMemberIsHost(hostId, groupId, (host, group) -> {
-            group.validateGroupIsDeletable();
+            group.validateGroupIsProceeding();
             groupRepository.deleteById(groupId);
         });
     }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
@@ -86,10 +86,9 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
         모임에_참여한다(participantAccessToken, groupId);
 
         모임을_삭제한다(hostAccessToken, groupId)
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", Matchers.is("GROUP_ERROR_014"));
+                .statusCode(HttpStatus.NO_CONTENT.value());
 
         모임을_조회한다(hostAccessToken, groupId)
-                .statusCode(HttpStatus.OK.value());
+                .statusCode(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
@@ -140,8 +140,7 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
         모임에_참여한다(participantAccessToken, groupId);
 
         모임을_수정한다(hostAccessToken, groupId, DUDU_STUDY)
-                .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", Matchers.is("GROUP_ERROR_014"));
+                .statusCode(HttpStatus.OK.value());
     }
 
     @DisplayName("모임의 장소를 수정한다")

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/GroupTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.momo.group.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import static com.woowacourse.momo.fixture.GroupFixture.MOMO_STUDY;
 import static com.woowacourse.momo.fixture.GroupFixture.MOMO_TRAVEL;
@@ -170,20 +171,16 @@ class GroupTest {
             group.participate(DUDU.toMember());
         }
 
-        @DisplayName("참여자가 존재하는 모임은 수정할 수 없습니다")
+        @DisplayName("참여자가 존재하는 모임을 수정할 수 있습니다")
         @Test
         void cannotUpdateGroupByExistParticipants() {
-            assertThatThrownBy(() -> update(group, MOMO_TRAVEL))
-                    .isInstanceOf(GroupException.class)
-                    .hasMessage("해당 모임은 참여자가 존재합니다.");
+            assertDoesNotThrow(() -> update(group, MOMO_TRAVEL));
         }
 
-        @DisplayName("참여자가 존재하는 모임은 삭제할 수 없습니다")
+        @DisplayName("참여자가 존재하는 모임을 삭제할 수 있습니다")
         @Test
         void cannotDeleteGroupByExistParticipants() {
-            assertThatThrownBy(group::validateGroupIsDeletable)
-                    .isInstanceOf(GroupException.class)
-                    .hasMessage("해당 모임은 참여자가 존재합니다.");
+            assertDoesNotThrow(group::validateGroupIsDeletable);
         }
     }
 
@@ -364,7 +361,7 @@ class GroupTest {
 
     @DisplayName("참여자가 가득한 모임에 대해, 모집이 마감되었는지 확인한다")
     @ParameterizedTest
-    @CsvSource(value = {"2,true", "3,false"})
+    @CsvSource(value = {"2,false", "3,false"})
     void isFinishedRecruitmentWhenParticipantsFull(int capacity, boolean expected) {
         Group group = MOMO_STUDY.builder()
                 .capacity(capacity)

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/GroupTest.java
@@ -60,7 +60,7 @@ class GroupTest {
         @DisplayName("조기마감된 모임은 더이상 삭제할 수 없습니다")
         @Test
         void cannotDeleteGroupByClosedEarly() {
-            assertThatThrownBy(group::validateGroupIsDeletable)
+            assertThatThrownBy(group::validateGroupIsProceeding)
                     .isInstanceOf(GroupException.class)
                     .hasMessage("해당 모임은 조기 마감되어 있습니다.");
         }
@@ -121,7 +121,7 @@ class GroupTest {
         @DisplayName("마감기한이 지나버린 모임은 더이상 삭제할 수 없습니다")
         @Test
         void cannotDeleteGroupByDeadlinePassed() {
-            assertThatThrownBy(group::validateGroupIsDeletable)
+            assertThatThrownBy(group::validateGroupIsProceeding)
                     .isInstanceOf(GroupException.class)
                     .hasMessage("해당 모임은 마감기한이 지났습니다.");
         }
@@ -180,7 +180,7 @@ class GroupTest {
         @DisplayName("참여자가 존재하는 모임을 삭제할 수 있습니다")
         @Test
         void cannotDeleteGroupByExistParticipants() {
-            assertDoesNotThrow(group::validateGroupIsDeletable);
+            assertDoesNotThrow(group::validateGroupIsProceeding);
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryTest.java
@@ -172,7 +172,7 @@ class GroupSearchRepositoryTest {
         List<Group> actual = groupSearchRepository.findGroups(request.toFindCondition(), pageable).getContent();
 
         assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(List.of(group5, group4, group2, group1));
+                .isEqualTo(List.of(group5, group4, group3, group2, group1));
     }
 
     @DisplayName("마감기한이 적은 순으로 목록을 조회한다")
@@ -199,7 +199,7 @@ class GroupSearchRepositoryTest {
         List<Group> actual = groupSearchRepository.findGroups(request.toFindCondition(), pageable).getContent();
 
         assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(List.of(group2, group1));
+                .isEqualTo(List.of(group3, group2, group1));
     }
 
     @DisplayName("키워드가 포함된 목록 중 마감기한이 적게 남은 순으로 목록을 조회한다")
@@ -227,7 +227,7 @@ class GroupSearchRepositoryTest {
         List<Group> actual = groupSearchRepository.findGroups(request.toFindCondition(), pageable).getContent();
 
         assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(List.of(group4, group2, group5, group1));
+                .isEqualTo(List.of(group4, group2, group5, group1, group3));
     }
 
     @DisplayName("키워드가 포함되고 모집 마감이 완료된 모임을 제외한 모임 중 마감기한이 적게 남은 순으로 목록을 조회한다")
@@ -242,7 +242,7 @@ class GroupSearchRepositoryTest {
         List<Group> actual = groupSearchRepository.findGroups(request.toFindCondition(), pageable).getContent();
 
         assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(List.of(group2, group1));
+                .isEqualTo(List.of(group2, group1, group3));
     }
 
     @DisplayName("키워드가 포함되고 모집 마감이 완료된 모임을 제외한 모임 중 마감기한이 적게 남은 순으로 참여한 모임 목록을 조회한다")
@@ -274,7 +274,7 @@ class GroupSearchRepositoryTest {
                 .getContent();
 
         assertThat(actual).usingRecursiveComparison()
-                .isEqualTo(List.of(group2, group1));
+                .isEqualTo(List.of(group2, group1, group3));
     }
 
     private static class FindRequestBuilder {

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupModifyServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupModifyServiceTest.java
@@ -3,6 +3,7 @@ package com.woowacourse.momo.group.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import static com.woowacourse.momo.fixture.GroupFixture.DUDU_STUDY;
 import static com.woowacourse.momo.fixture.GroupFixture.MOMO_STUDY;
@@ -166,7 +167,7 @@ class GroupModifyServiceTest {
                 .hasMessage("해당 모임의 주최자가 아닙니다.");
     }
 
-    @DisplayName("주최자 외 참여자가 있을 때 모임을 수정하면 예외가 발생한다")
+    @DisplayName("주최자 외 참여자가 있을 때 모임을 수정할 수 있다")
     @Test
     void updateExistParticipants() {
         long groupId = group.getId();
@@ -175,9 +176,7 @@ class GroupModifyServiceTest {
         group.participate(participant);
 
         GroupUpdateRequest request = DUDU_STUDY.toUpdateRequest();
-        assertThatThrownBy(() -> groupModifyService.update(hostId, groupId, request))
-                .isInstanceOf(GroupException.class)
-                .hasMessage("해당 모임은 참여자가 존재합니다.");
+        assertDoesNotThrow(() -> groupModifyService.update(hostId, groupId, request));
     }
 
     @DisplayName("모집 마감된 모임을 수정할 경우 예외가 발생한다")
@@ -185,13 +184,12 @@ class GroupModifyServiceTest {
     void updateFinishedRecruitmentGroup() {
         long groupId = group.getId();
         long hostId = host.getId();
-
-        group.participate(participant);
+        group.closeEarly();
 
         GroupUpdateRequest request = DUDU_STUDY.toUpdateRequest();
         assertThatThrownBy(() -> groupModifyService.update(hostId, groupId, request))
                 .isInstanceOf(GroupException.class)
-                .hasMessage("해당 모임은 참여자가 존재합니다.");
+                .hasMessage("해당 모임은 조기 마감되어 있습니다.");
     }
 
     @DisplayName("모임 장소를 업데이트한다")
@@ -259,7 +257,7 @@ class GroupModifyServiceTest {
                 .hasMessage("해당 모임의 주최자가 아닙니다.");
     }
 
-    @DisplayName("주최자를 제외하고 참여자가 있을 경우 모임을 삭제하면 예외가 발생한다")
+    @DisplayName("주최자를 제외하고 참여자가 있을 경우 모임을 삭제할 수 있다")
     @Test
     void deleteExistParticipants() {
         long groupId = group.getId();
@@ -267,9 +265,7 @@ class GroupModifyServiceTest {
 
         participateService.participate(group.getId(), participant.getId());
 
-        assertThatThrownBy(() -> groupModifyService.delete(hostId, groupId))
-                .isInstanceOf(GroupException.class)
-                .hasMessage("해당 모임은 참여자가 존재합니다.");
+        assertDoesNotThrow(() -> groupModifyService.delete(hostId, groupId));
     }
 
     @DisplayName("모집 마감된 모임을 삭제할 경우 예외가 발생한다")
@@ -277,11 +273,10 @@ class GroupModifyServiceTest {
     void deleteFinishedRecruitmentGroup() {
         long groupId = group.getId();
         long hostId = host.getId();
-
-        group.participate(participant);
+        group.closeEarly();
 
         assertThatThrownBy(() -> groupModifyService.delete(hostId, groupId))
                 .isInstanceOf(GroupException.class)
-                .hasMessage("해당 모임은 참여자가 존재합니다.");
+                .hasMessage("해당 모임은 조기 마감되어 있습니다.");
     }
 }


### PR DESCRIPTION
### 변경 사항

회의 결과에 따라 마감로직을 변경하였습니다. 

1. 모임 조회 시 참여자의 수가 가득 찼는지 확인하는 로직을 제거하였습니다.
2. 모임 수정 시 참여자의 수가 가득 찼는지 확인하는 로직을 제거하였습니다.
3. Querydsl 로직 중 참여자 수로 마감 여부를 검사하는 로직을 제거하였습니다.
4. (1)로 인해 영향받는 테스트 코드를 최대한 제거하지 않고 테스트 자체를 변경하였습니다.