### PR TITLE
[BE] Access Token만료 후, Refresh Token을 통한 재접근 불가 오류

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
@@ -31,7 +31,7 @@ public class RefreshTokenAuthInterceptor implements HandlerInterceptor {
         Token token = tokenRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN));
 
-        if (!token.isSameRefreshToken(refreshToken)) {
+        if (token.isDifferentRefreshToken(refreshToken)) {
             throw new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN);
         }
         return true;

--- a/backend/src/main/java/com/woowacourse/momo/auth/domain/Token.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/domain/Token.java
@@ -35,8 +35,8 @@ public class Token {
         this.refreshToken = refreshToken;
     }
 
-    public boolean isSameRefreshToken(String refreshToken) {
-        return this.refreshToken.equals(refreshToken);
+    public boolean isDifferentRefreshToken(String refreshToken) {
+        return !this.refreshToken.equals(refreshToken);
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/backend/src/main/java/com/woowacourse/momo/auth/domain/Token.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/domain/Token.java
@@ -24,7 +24,7 @@ public class Token {
     private Long id;
 
     @OneToOne
-    @JoinColumn
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @Column(nullable = false)

--- a/backend/src/test/java/com/woowacourse/momo/auth/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/service/TokenServiceTest.java
@@ -1,0 +1,90 @@
+package com.woowacourse.momo.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.woowacourse.momo.fixture.MemberFixture.DUDU;
+import static com.woowacourse.momo.fixture.MemberFixture.MOMO;
+
+import java.util.Optional;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.woowacourse.momo.auth.domain.Token;
+import com.woowacourse.momo.auth.domain.TokenRepository;
+import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.member.domain.MemberRepository;
+
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@SpringBootTest
+class TokenServiceTest {
+
+    private final TokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+    private final TokenService tokenService;
+    private final EntityManager entityManager;
+
+    private Member momo;
+    private Member dudu;
+
+    @BeforeEach
+    void setUp() {
+        momo = memberRepository.save(MOMO.toMember());
+        dudu = memberRepository.save(DUDU.toMember());
+        String refreshToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkluQm9uZyBTb25nIiwiaWF0IjoxNTE2MjM5MDIyfQ.XikBQw8OOU87xoWsYVTJjx6Vpb114WW4FfBoWqqVYHU";
+        tokenService.synchronizeRefreshToken(momo, refreshToken);
+
+        synchronize();
+    }
+
+    @DisplayName("리프레시 토큰을 저장한다")
+    @Test
+    void saveRefreshToken() {
+        String refreshToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkluQm9uZyBTb25nIiwiaWF0IjoxNTE2MjM5MDIyfQ.XikBQw8OOU87xoWsYVTJjx6Vpb114WW4FfBoWqqVYHU";
+
+        tokenService.synchronizeRefreshToken(dudu, refreshToken);
+        synchronize();
+
+        Optional<Token> actual = tokenRepository.findByMemberId(dudu.getId());
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getRefreshToken()).isEqualTo(refreshToken);
+    }
+
+    @DisplayName("리프레시 토큰을 업데이트한다")
+    @Test
+    void updateRefreshToken() {
+        String newRefreshToken = "new_bGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkluQm9uZyBTb25nIiwiaWF0IjoxNTE2MjM5MDIyfQ.XikBQw8OOU87xoWsYVTJjx6Vpb114WW4FfBoWqqVYHU";
+
+        tokenService.synchronizeRefreshToken(momo, newRefreshToken);
+        synchronize();
+
+        Optional<Token> actual = tokenRepository.findByMemberId(momo.getId());
+        assertThat(actual).isPresent();
+        assertThat(actual.get().getRefreshToken()).isEqualTo(newRefreshToken);
+    }
+
+    @DisplayName("리프레시 토큰을 삭제한다")
+    @Test
+    void deleteByMemberId() {
+        tokenService.deleteByMemberId(momo.getId());
+        synchronize();
+
+        Optional<Token> actual = tokenRepository.findByMemberId(momo.getId());
+        assertThat(actual).isEmpty();
+    }
+
+    void synchronize() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/auth/support/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/support/JwtTokenProviderTest.java
@@ -1,0 +1,34 @@
+package com.woowacourse.momo.auth.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.woowacourse.momo.global.exception.exception.MomoException;
+
+class JwtTokenProviderTest {
+
+    private String secretKey = "eyasfQciOiJIUzI1NiIvLoAR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCLoCP1lIjoiSm9obiBEV9UiLCJpYXBCusE1MTYyMzkwMjJ9.123asdfa8s7d6f987qweahqwculaoxce80k1i2o387tg";
+    private JwtTokenProvider tokenProvider = new JwtTokenProvider(secretKey, 0, 0);
+
+    @DisplayName("토큰의 유효 기간이 만료되었을 경우 예외가 발생한다")
+    @Test
+    void validateTokenExpiration() {
+        String accessToken = tokenProvider.createAccessToken(1L);
+
+        assertThatThrownBy(() -> tokenProvider.validateTokenNotUsable(accessToken))
+                .isInstanceOf(MomoException.class)
+                .hasMessageContaining("토큰의 유효기간이 만료되었습니다.");
+    }
+
+    @DisplayName("애플리케이션에서 생성한 토큰이 아니면 예외가 발생한다")
+    @Test
+    void validateInvalidToken() {
+        String accessToken = "asdaxlckvhlasfjh";
+
+        boolean actual = tokenProvider.validateTokenNotUsable(accessToken);
+        assertThat(actual).isTrue();
+    }
+}


### PR DESCRIPTION
## ✨ Issue
- #377 

## 🐞 버그가 발생한 기능
Access Token만료 후, Refresh Token을 통한 재접근 플로우가 작동되지 않았다.

## ✅ 확인 내용
백엔드의 로직 확인 결과 백엔드 상의 오류는 발견하지 못하였다.

> 해당 문제는 프론트쪽에서 `AUTH_ERROR_001`에러 코드를 받았을 때, 리프레시 토큰을 통해 엑세스 토큰을 요청 후 사용하도록 수정을 해야하는 것으로 판단된다.

### 확인한 Refresh Token발급 관련 플로우
- [x] 로그인을 하면 Refresh Token과 Access Token을 발급
    - [x] Refresh Token은 DB에 저장
- [x] Client는 Access Token을 통해 데이터를 요청하다가 Token유효기간이 만료되면 에러 발생
    - [x] `AUTH_ERROR_001`
- [x] Client가 Refresh Token으로 Access Token을 재요청 및 새로운 Access Token반환
    - [x] Refresh Token에서 MemberId를 추출한 후, 해당 회원이 가진 Refresh Token이 맞는지 확인
- [x] Access Token을 통해 다시 정보 요청
- [x] 로그아웃을 한다면 Refresh Token삭제

계획대로 `AUTH_ERROR_001`을 던져주는 것과 Refresh Token 재발급 API에 대한 확인을 완료하였다.

## ❗️ 변경사항
- 코드를 확인하며 Token의 기간 만료시 발생하는 예외에 대한 테스트 코드가 없어서 테스트 추가
- 그 외에도 몇몇 테스트 코드 추가
- 항상 `!`를 통해 항상 반대의 값을 필요로 하는 로직을 반대로 변경
- Token객체의 누락된 `@JoinColumn`의 외래키 명시