### PR TITLE
[BE] 모집이 마감된 모임에 대하여 찜하기/찜취소 기능 에러가 발생하는 현상

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -108,7 +108,6 @@ public class Group {
     }
 
     public void like(Member member) {
-        validateGroupIsProceeding();
         favorites.like(this, member);
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -112,7 +112,6 @@ public class Group {
     }
 
     public void cancelLike(Member member) {
-        validateGroupIsProceeding();
         favorites.cancel(member);
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/favorite/FavoriteTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/favorite/FavoriteTest.java
@@ -1,0 +1,38 @@
+package com.woowacourse.momo.group.domain.favorite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static com.woowacourse.momo.fixture.GroupFixture.MOMO_STUDY;
+import static com.woowacourse.momo.fixture.MemberFixture.DUDU;
+import static com.woowacourse.momo.fixture.MemberFixture.MOMO;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.woowacourse.momo.group.domain.Group;
+import com.woowacourse.momo.member.domain.Member;
+
+class FavoriteTest {
+
+    private static final Member MEMBER_MOMO = MOMO.toMember();
+    private static final Member MEMBER_DUDU = DUDU.toMember();
+    private static final Group STUDY_GROUP = MOMO_STUDY.toGroup(MEMBER_MOMO);
+
+    @DisplayName("동일한 회원이면 True를 반환한다")
+    @Test
+    void isSameMember() {
+        Favorite favorite = new Favorite(STUDY_GROUP, MEMBER_MOMO);
+        boolean actual = favorite.isSameMember(MEMBER_MOMO);
+
+        assertThat(actual).isTrue();
+    }
+
+    @DisplayName("동일한 회원이 아닐 경우 False를 반환한다")
+    @Test
+    void isNotSameMember() {
+        Favorite favorite = new Favorite(STUDY_GROUP, MEMBER_MOMO);
+        boolean actual = favorite.isSameMember(MEMBER_DUDU);
+
+        assertThat(actual).isFalse();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/favorite/FavoritesTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/favorite/FavoritesTest.java
@@ -1,0 +1,62 @@
+package com.woowacourse.momo.group.domain.favorite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static com.woowacourse.momo.fixture.GroupFixture.MOMO_STUDY;
+import static com.woowacourse.momo.fixture.MemberFixture.DUDU;
+import static com.woowacourse.momo.fixture.MemberFixture.MOMO;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.woowacourse.momo.group.domain.Group;
+import com.woowacourse.momo.group.exception.GroupException;
+import com.woowacourse.momo.member.domain.Member;
+
+class FavoritesTest {
+
+    private static final Member HOST = MOMO.toMember();
+    private static final Member MEMBER = DUDU.toMember();
+    private static final Group STUDY_GROUP = MOMO_STUDY.toGroup(HOST);
+
+    @DisplayName("모임을 찜한다")
+    @Test
+    void like() {
+        Favorites favorites = new Favorites();
+        favorites.like(STUDY_GROUP, MEMBER);
+
+        assertThat(favorites.hasMember(MEMBER)).isTrue();
+    }
+
+    @DisplayName("이미 찜한 모임을 찜하면 예외가 발생한다")
+    @Test
+    void validateMemberNotYetLike() {
+        Favorites favorites = new Favorites();
+        favorites.like(STUDY_GROUP, MEMBER);
+
+        assertThatThrownBy(() -> favorites.like(STUDY_GROUP, MEMBER))
+                .isInstanceOf(GroupException.class)
+                .hasMessage("이미 찜한 모임입니다.");
+    }
+
+    @DisplayName("모임을 찜하기를 취소한다")
+    @Test
+    void cancel() {
+        Favorites favorites = new Favorites();
+        favorites.like(STUDY_GROUP, MEMBER);
+
+        favorites.cancel(MEMBER);
+        assertThat(favorites.hasMember(MEMBER)).isFalse();
+    }
+
+    @DisplayName("찜하지 않은 모임을 찜하기 취소를 하면 예외가 발생한다")
+    @Test
+    void validateMemberAlreadyLike() {
+        Favorites favorites = new Favorites();
+
+        assertThatThrownBy(() -> favorites.cancel(MEMBER))
+                .isInstanceOf(GroupException.class)
+                .hasMessage("찜하지 않은 모임입니다.");
+    }
+}

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/search/GroupSearchRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/search/GroupSearchRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.group.infrastructure.querydsl;
+package com.woowacourse.momo.group.domain.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/backend/src/test/java/com/woowacourse/momo/group/service/LikeServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/LikeServiceTest.java
@@ -60,9 +60,42 @@ class LikeServiceTest {
         assertThat(expected).isTrue();
     }
 
-    @DisplayName("모임을 찜하기를 취소한다")
+    @DisplayName("마감된 모임을 찜한다")
+    @Test
+    void likeClosedGroup() {
+        group.closeEarly();
+        long groupId = group.getId();
+        long userId = user.getId();
+
+        likeService.like(groupId, userId);
+        synchronize();
+
+        Group findGroup = groupFindService.findGroup(groupId);
+        boolean expected = findGroup.isMemberLiked(user);
+
+        assertThat(expected).isTrue();
+    }
+
+    @DisplayName("모임의 찜하기를 취소한다")
     @Test
     void cancel() {
+        long groupId = group.getId();
+        long userId = user.getId();
+
+        likeService.like(groupId, userId);
+        likeService.cancel(groupId, userId);
+        synchronize();
+
+        Group findGroup = groupFindService.findGroup(groupId);
+        boolean expected = findGroup.isMemberLiked(user);
+
+        assertThat(expected).isFalse();
+    }
+
+    @DisplayName("마감된 모임의 찜하기를 취소한다")
+    @Test
+    void cancelClosedGroup() {
+        group.closeEarly();
         long groupId = group.getId();
         long userId = user.getId();
 


### PR DESCRIPTION
## ✨ Issue
- #375 

## 🐞 버그가 발생한 기능
모집이 마감된 모임에 대하여 찜하기/찜취소 기능 에러가 발생하는 현상

## 🚀 진행한 업무
- 마감된 모집에 대하여 찜하기/찜 취소 기능이 불가능하던 오류 수정
- 부족했던 찜 기능 테스트 코드 추가

closed #375 