### PR TITLE
[BE] QueryDSL 이용하여 pagination 할 때 limit 이 설정되지 않는 현상

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/ConditionFilter.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/ConditionFilter.java
@@ -5,11 +5,7 @@ import static com.woowacourse.momo.group.domain.QGroup.group;
 import java.time.LocalDateTime;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.NumberPath;
 
 import com.woowacourse.momo.category.domain.Category;
 import com.woowacourse.momo.group.domain.search.SearchCondition;
@@ -54,16 +50,6 @@ public class ConditionFilter {
         if (orderByDeadline) {
             booleanBuilder.and(afterNow());
         }
-    }
-
-    private BooleanExpression isNotParticipantsFull() {
-        NumberPath<Integer> capacity = group.participants.capacity.value;
-
-        NumberExpression<Integer> sizeWithoutHost = group.participants.participants.size();
-        Expression<Integer> hostSize = Expressions.constant(1);
-        NumberExpression<Integer> participantsSize = sizeWithoutHost.add(hostSize);
-
-        return capacity.gt(participantsSize);
     }
 
     private BooleanExpression notClosedEarly() {

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -58,6 +58,21 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                 .innerJoin(group.favorites.favorites, favorite)
                 .fetchJoin()
                 .where(
+                        group.id.in(findLikedGroupIds(condition, member, pageable))
+                )
+                .orderBy(orderByDeadlineAsc(condition.orderByDeadline()).toArray(OrderSpecifier[]::new))
+                .fetch();
+
+        return PageableExecutionUtils.getPage(groups, pageable, groups::size);
+    }
+
+    private List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
+        return queryFactory
+                .select(group.id)
+                .from(group)
+                .leftJoin(group.participants.participants, participant)
+                .innerJoin(group.favorites.favorites, favorite)
+                .where(
                         favorite.member.eq(member),
                         conditionFilter.filterByCondition(condition)
                 )
@@ -65,8 +80,6 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-
-        return PageableExecutionUtils.getPage(groups, pageable, groups::size);
     }
 
     private Page<Group> findGroups(SearchCondition condition, Pageable pageable,


### PR DESCRIPTION
## ✨ Issue
- #383

## 🐞 문제 상황
![image](https://user-images.githubusercontent.com/57744251/192950957-6634ef2a-e379-4eb2-9ed9-5c0a44aba7e5.png)

### 🤮 문제 원인
하이버네이트 특성상 `OneToMany`관계에서 `fetchJoin()`과 `limit()`을 같이 사용하니 쿼리상으로는 Full Scan을 한 후, 페이지네이션은 JVM상에서 데이터를 필터링 하는 방법으로 구동이 되었다.

### 🏆 해결 방법
#### 🥈 해결방법 1. OneToMany 관계를 ManyToOne의 방향으로 스캔을 하며 DB 스캔시 필터링된 데이터만 가져오도록 하는 방법

**적용한 결과**
우리의 쿼리 특성상 필터링 기능을 사용하며 Group, Participant, Favorite 테이블을 Join하며 필터링 및 결과 조회를 진행하고 있다. Favorite과 Group의 연관관계를 역으로 진행하여 Favorite테이블을 통해 조회를 한다고 하여도, Participant 테이블을 Join하는 과정에서 OneToMany가 발생하여 문제 해결이 안된다.
```java
    @Override
    public Page<Group> findLikedGroups(SearchCondition condition, Member member, Pageable pageable) {
        List<Group> groups = queryFactory
                .select(favorite.group)
                .from(favorite)
                .innerJoin(favorite.group, group)
                .leftJoin(group.participants.participants, participant) // 해당 과정에서 OneToMany가 발생
                .fetchJoin()
                .where(
                        favorite.member.eq(member),
                        conditionFilter.filterByCondition(condition)
                )
                .groupBy(favorite.group.id)
                .orderBy(orderByDeadlineAsc(condition.orderByDeadline()).toArray(OrderSpecifier[]::new))
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();

        return PageableExecutionUtils.getPage(groups, pageable, groups::size);
    }
```

#### 🥇 해결방법 2. fetchJoin없이 엔티티의 모든 데이터가 아닌 id값만 가져오는 쿼리를 날린 후, 해당 ID를 IN절에 넣어 필요한 데이터를 가져오도록 하는 방법
> 즉, ID를 조회하는 쿼리와 데이터를 조회하는 쿼리로 2번을 날리게 한다.

**적용한 결과**
해당 방법은 1번 날라가던 쿼리가 2번으로 변경된다는 단점이 있긴 하나 JVM의 부담을 줄여줄 수 있다. 실제로 문제였던 경고 메시지 또한 발생하지 않아 해당 쿼리로 적용하였다.
```java
    @Override
    public Page<Group> findLikedGroups(SearchCondition condition, Member member, Pageable pageable) {
        List<Group> groups = queryFactory
                .selectFrom(group)
                .leftJoin(group.participants.participants, participant)
                .innerJoin(group.favorites.favorites, favorite)
                .fetchJoin()
                .where(
                        group.id.in(findLikedGroupIds(condition, member, pageable))
                )
                .orderBy(orderByDeadlineAsc(condition.orderByDeadline()).toArray(OrderSpecifier[]::new))
                .fetch();

        return PageableExecutionUtils.getPage(groups, pageable, groups::size);
    }

    private List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
        return queryFactory
                .select(group.id)
                .from(group)
                .leftJoin(group.participants.participants, participant)
                .innerJoin(group.favorites.favorites, favorite)
                .where(
                        favorite.member.eq(member),
                        conditionFilter.filterByCondition(condition)
                )
                .orderBy(orderByDeadlineAsc(condition.orderByDeadline()).toArray(OrderSpecifier[]::new))
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();
    }
```
- ID조회 쿼리
   <img width="397" alt="image" src="https://user-images.githubusercontent.com/57744251/192974249-0c0d33de-ce38-4832-9ca3-b1d2cef36a5e.png">
- 엔티티 조회 쿼리
   <img width="481" alt="image" src="https://user-images.githubusercontent.com/57744251/192974358-403c318f-55ea-43cd-984d-7274f04f1bab.png">
