### PR TITLE
[FE] 탈퇴한 아이디로 다시 회원가입을 할 수 없는 현상

### DIFF
--- a/frontend/src/components/Card/index.tsx
+++ b/frontend/src/components/Card/index.tsx
@@ -37,7 +37,7 @@ function Card({ group }: CardProps) {
             <div>
               <S.Title>{name}</S.Title>
               <S.HostName>
-                {host.name ? host.name : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+                {host.name || GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
               </S.HostName>
             </div>
             <S.Capacity>

--- a/frontend/src/components/Card/index.tsx
+++ b/frontend/src/components/Card/index.tsx
@@ -3,6 +3,7 @@ import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { EmptyHeartSVG, FilledHeartSVG } from 'assets/svg';
+import { GUIDE_MESSAGE } from 'constants/message';
 import { BROWSER_PATH } from 'constants/path';
 import { GroupSummary } from 'types/data';
 import { getCategoryImage } from 'utils/category';
@@ -35,7 +36,9 @@ function Card({ group }: CardProps) {
           <S.Left>
             <div>
               <S.Title>{name}</S.Title>
-              <S.HostName>{host.name}</S.HostName>
+              <S.HostName>
+                {host.name ? host.name : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+              </S.HostName>
             </div>
             <S.Capacity>
               <span>{numOfParticipant}</span>명 / 최대 <span>{capacity}</span>명

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -18,6 +18,7 @@ const GUIDE_MESSAGE = {
     CONFIRM_WITHDRAWAL_REQUEST:
       '정말로 탈퇴하실 건가요? 이 작업은 돌이킬 수 없어요 🥺',
     SUCCESS_WITHDRAWAL_REQUEST: '회원 탈퇴에 성공했어요. 다음에 다시 만나요 😊',
+    WITHDRAWAL_MEMBER: '탈퇴한 회원입니다.',
   },
   GROUP: {
     CONFIRM_CLOSE_REQUEST: '모임 모집을 마감하시겠어요?',

--- a/frontend/src/pages/Detail/SideBar/Info/index.tsx
+++ b/frontend/src/pages/Detail/SideBar/Info/index.tsx
@@ -64,7 +64,7 @@ function Info({
           <S.Wrapper>
             <PersonSVG width={svgSize} />
             <S.Text>
-              {host.name ? host.name : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+              {host.name || GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
             </S.Text>
           </S.Wrapper>
         </div>

--- a/frontend/src/pages/Detail/SideBar/Info/index.tsx
+++ b/frontend/src/pages/Detail/SideBar/Info/index.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 import { ClockSVG, LocationSVG, PencilSVG } from 'assets/svg';
 import CategorySVG from 'components/svg/Category';
 import PersonSVG from 'components/svg/Person';
+import { GUIDE_MESSAGE } from 'constants/message';
 import useModal from 'hooks/useModal';
 import { loginState } from 'store/states';
 import { CategoryType, GroupDetailData, GroupParticipants } from 'types/data';
@@ -62,7 +63,9 @@ function Info({
           </S.Wrapper>
           <S.Wrapper>
             <PersonSVG width={svgSize} />
-            <S.Text>{host.name}</S.Text>
+            <S.Text>
+              {host.name ? host.name : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+            </S.Text>
           </S.Wrapper>
         </div>
         {isHost && (

--- a/frontend/src/pages/Detail/SideBar/Participants/index.tsx
+++ b/frontend/src/pages/Detail/SideBar/Participants/index.tsx
@@ -26,16 +26,14 @@ function Participants({ host, capacity, participants }: ParticipantsProps) {
         <S.Wrapper>
           <CrownSVG width={svgSize} />
           <S.HostText>
-            {host.name ? host.name : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+            {host.name || GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
           </S.HostText>
         </S.Wrapper>
         {participantsWithoutHost.map(participant => (
           <S.Wrapper key={participant.id}>
             <PersonSVG width={svgSize} />
             <S.Text>
-              {participant.name
-                ? participant.name
-                : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+              {participant.name || GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
             </S.Text>
           </S.Wrapper>
         ))}

--- a/frontend/src/pages/Detail/SideBar/Participants/index.tsx
+++ b/frontend/src/pages/Detail/SideBar/Participants/index.tsx
@@ -1,5 +1,6 @@
 import { CrownSVG } from 'assets/svg';
 import PersonSVG from 'components/svg/Person';
+import { GUIDE_MESSAGE } from 'constants/message';
 import { GroupDetailData, GroupParticipants } from 'types/data';
 
 import * as S from './index.styled';
@@ -24,13 +25,17 @@ function Participants({ host, capacity, participants }: ParticipantsProps) {
       <S.Box>
         <S.Wrapper>
           <CrownSVG width={svgSize} />
-          <S.HostText>{host.name}</S.HostText>
+          <S.HostText>
+            {host.name ? host.name : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
+          </S.HostText>
         </S.Wrapper>
         {participantsWithoutHost.map(participant => (
           <S.Wrapper key={participant.id}>
             <PersonSVG width={svgSize} />
             <S.Text>
-              {participant.name ? participant.name : '탈퇴한 회원입니다.'}
+              {participant.name
+                ? participant.name
+                : GUIDE_MESSAGE.MEMBER.WITHDRAWAL_MEMBER}
             </S.Text>
           </S.Wrapper>
         ))}

--- a/frontend/src/pages/Detail/SideBar/Participants/index.tsx
+++ b/frontend/src/pages/Detail/SideBar/Participants/index.tsx
@@ -29,7 +29,9 @@ function Participants({ host, capacity, participants }: ParticipantsProps) {
         {participantsWithoutHost.map(participant => (
           <S.Wrapper key={participant.id}>
             <PersonSVG width={svgSize} />
-            <S.Text>{participant.name}</S.Text>
+            <S.Text>
+              {participant.name ? participant.name : '탈퇴한 회원입니다.'}
+            </S.Text>
           </S.Wrapper>
         ))}
       </S.Box>


### PR DESCRIPTION
## Issue

- #372 

## Description (optional)

- 탈퇴한 회원의 이름은 빈 문자열이 되는 형식으로 바뀌었기에, 이에 맞게 프론트에서 참여자 중 탈퇴한 회원이 있을 경우에 이를 표시해주도록 변경

closed #372 