### PR TITLE
[BE] 에러 메시지 축약

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -12,6 +12,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
@@ -42,7 +44,7 @@ public class AuthInterceptor implements HandlerInterceptor {
     private void validateToken(HttpServletRequest request) {
         String token = AuthorizationExtractor.extract(request);
         if (jwtTokenProvider.validateTokenNotUsable(token)) {
-            throw new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_TOKEN);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthInterceptor.java
@@ -16,8 +16,6 @@ import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthOptionalInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthOptionalInterceptor.java
@@ -12,6 +12,8 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
@@ -47,7 +49,7 @@ public class AuthOptionalInterceptor implements HandlerInterceptor {
 
         String token = AuthorizationExtractor.extract(request);
         if (jwtTokenProvider.validateTokenNotUsable(token)) {
-            throw new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_TOKEN);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthOptionalInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthOptionalInterceptor.java
@@ -16,8 +16,6 @@ import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @RequiredArgsConstructor
 public class AuthOptionalInterceptor implements HandlerInterceptor {

--- a/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/RefreshTokenAuthInterceptor.java
@@ -9,9 +9,9 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.domain.Token;
 import com.woowacourse.momo.auth.domain.TokenRepository;
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.support.AuthorizationExtractor;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @RequiredArgsConstructor
@@ -24,15 +24,15 @@ public class RefreshTokenAuthInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String refreshToken = AuthorizationExtractor.extract(request);
         if (jwtTokenProvider.validateTokenNotUsable(refreshToken)) {
-            throw new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN);
+            throw new MomoException(AuthErrorCode.AUTH_INVALID_TOKEN);
         }
 
         Long memberId = jwtTokenProvider.getPayload(refreshToken);
         Token token = tokenRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN));
+                .orElseThrow(() -> new MomoException(AuthErrorCode.AUTH_INVALID_TOKEN));
 
         if (token.isDifferentRefreshToken(refreshToken)) {
-            throw new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN);
+            throw new MomoException(AuthErrorCode.AUTH_INVALID_TOKEN);
         }
         return true;
     }

--- a/backend/src/main/java/com/woowacourse/momo/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package com.woowacourse.momo.auth.controller;
 
 import javax.validation.Valid;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,7 +14,6 @@ import com.woowacourse.momo.auth.config.Authenticated;
 import com.woowacourse.momo.auth.config.AuthenticationPrincipal;
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 
@@ -31,13 +29,6 @@ public class AuthController {
         LoginResponse response = authService.login(request);
 
         return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/signup")
-    public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-        authService.signUp(request);
-
-        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @Authenticated

--- a/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
@@ -1,0 +1,45 @@
+package com.woowacourse.momo.auth.exception;
+
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+
+public enum AuthErrorCode implements ErrorCode {
+    AUTH_EXPIRED_TOKEN(401, "AUTH_001", "토큰의 유효기간이 만료되었습니다."),
+    AUTH_INVALID_TOKEN(401, "AUTH_002", "토큰이 유효하지 않습니다."),
+    AUTH_REQUIRED_LOGIN(401, "AUTH_003", "로그인이 필요합니다."),
+    AUTH_DELETE_NO_HOST(403, "AUTH_004", "주최자가 아닌 사람은 모임을 수정하거나 삭제할 수 없습니다."),
+
+    OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_2XX_STATUS(500, "OAUTH_001", "구글에 전송한 Access 토큰 요청이 실패했습니다."),
+    OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY(500, "OAUTH_001", "구글에 요청한 Access 토큰에 대하여 응답 Body가 비어 있습니다."),
+    OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS(500, "OAUTH_001", "구글에 전송한 회원정보 요청이 실패했습니다."),
+    OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY(500, "OAUTH_001", "구글에 요청한 회원정보에 대하여 응답 Body가 비어 있습니다."),
+
+    SIGNUP_INVALID_ID(400, "SIGNUP_001", "잘못된 형식의 아이디입니다."),
+    SIGNUP_INVALID_PASSWORD(400, "SIGNUP_002", "잘못된 형식의 비밀번호입니다."),
+    SIGNUP_ALREADY_REGISTER(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
+    ;
+
+    private final int statusCode;
+    private final String errorCode;
+    private final String message;
+
+    AuthErrorCode(int statusCode, String errorCode, String message) {
+        this.statusCode = statusCode;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
@@ -3,6 +3,7 @@ package com.woowacourse.momo.auth.exception;
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
 
 public enum AuthErrorCode implements ErrorCode {
+
     AUTH_EXPIRED_TOKEN(401, "AUTH_001", "토큰의 유효기간이 만료되었습니다."),
     AUTH_INVALID_TOKEN(401, "AUTH_002", "토큰이 유효하지 않습니다."),
     AUTH_REQUIRED_LOGIN(401, "AUTH_003", "로그인이 필요합니다."),

--- a/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.momo.auth.exception;
 
-import com.woowacourse.momo.global.exception.exception.ErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
 public class AuthException extends MomoException {

--- a/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthException.java
@@ -1,0 +1,11 @@
+package com.woowacourse.momo.auth.exception;
+
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
+
+public class AuthException extends MomoException {
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
@@ -62,14 +64,14 @@ public class AuthService {
     private void validateUserIsNotExist(UserId userId) {
         Optional<Member> member = memberRepository.findByUserId(userId);
         if (member.isPresent()) {
-            throw new MomoException(GlobalErrorCode.SIGNUP_ALREADY_REGISTER);
+            throw new AuthException(AuthErrorCode.SIGNUP_ALREADY_REGISTER);
         }
     }
 
     public AccessTokenResponse reissueAccessToken(Long memberId) {
         boolean isExistMember = memberRepository.existsById(memberId);
         if (!isExistMember) {
-            throw new MomoException(GlobalErrorCode.AUTH_INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_INVALID_TOKEN);
         }
         String accessToken = jwtTokenProvider.createAccessToken(memberId);
         return new AccessTokenResponse(accessToken);

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.woowacourse.momo.auth.service;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,18 +8,14 @@ import lombok.RequiredArgsConstructor;
 import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.domain.Password;
 import com.woowacourse.momo.member.domain.UserId;
-import com.woowacourse.momo.member.domain.UserName;
 import com.woowacourse.momo.member.service.MemberFindService;
 
 @RequiredArgsConstructor
@@ -46,26 +40,6 @@ public class AuthService {
         tokenService.synchronizeRefreshToken(member, refreshToken);
 
         return new LoginResponse(accessToken, refreshToken);
-    }
-
-    @Transactional
-    public Long signUp(SignUpRequest request) {
-        UserId userId = UserId.momo(request.getUserId());
-        UserName userName = UserName.from(request.getName());
-        Password password = Password.encrypt(request.getPassword(), passwordEncoder);
-        Member member = new Member(userId, password, userName);
-
-        validateUserIsNotExist(userId);
-        Member savedMember = memberRepository.save(member);
-
-        return savedMember.getId();
-    }
-
-    private void validateUserIsNotExist(UserId userId) {
-        Optional<Member> member = memberRepository.findByUserId(userId);
-        if (member.isPresent()) {
-            throw new AuthException(AuthErrorCode.SIGNUP_ALREADY_REGISTER);
-        }
     }
 
     public AccessTokenResponse reissueAccessToken(Long memberId) {

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.auth.service.dto.response.OauthLinkResponse;
 import com.woowacourse.momo.auth.support.JwtTokenProvider;
@@ -59,12 +60,12 @@ public class OauthService {
         validateResponseStatusIsOk(responseEntity.getStatusCode());
 
         return Optional.ofNullable(responseEntity.getBody())
-                .orElseThrow(() -> new MomoException(GlobalErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY));
+                .orElseThrow(() -> new MomoException(AuthErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY));
     }
 
     private void validateResponseStatusIsOk(HttpStatus status) {
         if (!status.is2xxSuccessful()) {
-            throw new MomoException(GlobalErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS);
+            throw new MomoException(AuthErrorCode.OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/service/OauthService.java
@@ -17,7 +17,6 @@ import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.auth.support.google.GoogleConnector;
 import com.woowacourse.momo.auth.support.google.GoogleProvider;
 import com.woowacourse.momo.auth.support.google.dto.GoogleUserResponse;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.exception.AuthException;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthorizationExtractor {

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/AuthorizationExtractor.java
@@ -7,6 +7,8 @@ import javax.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
@@ -32,7 +34,7 @@ public class AuthorizationExtractor {
             }
         }
 
-        throw new MomoException(GlobalErrorCode.AUTH_REQUIRED_LOGIN);
+        throw new AuthException(AuthErrorCode.AUTH_REQUIRED_LOGIN);
     }
 
     public static boolean hasNotAuthHeader(HttpServletRequest request) {

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
@@ -16,6 +16,8 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
@@ -66,7 +68,7 @@ public class JwtTokenProvider {
 
             return claims.getBody().getExpiration().before(new Date());
         } catch (ExpiredJwtException e) {
-            throw new MomoException(GlobalErrorCode.AUTH_EXPIRED_TOKEN);
+            throw new AuthException(AuthErrorCode.AUTH_EXPIRED_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
             return true;
         }

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/JwtTokenProvider.java
@@ -18,8 +18,6 @@ import io.jsonwebtoken.security.Keys;
 
 import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.exception.AuthException;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Component
 public class JwtTokenProvider {

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
@@ -20,8 +20,7 @@ import lombok.RequiredArgsConstructor;
 import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.support.google.dto.GoogleTokenResponse;
 import com.woowacourse.momo.auth.support.google.dto.GoogleUserResponse;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
+    import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Getter
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/support/google/GoogleConnector.java
@@ -17,6 +17,7 @@ import org.springframework.web.client.RestTemplate;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.support.google.dto.GoogleTokenResponse;
 import com.woowacourse.momo.auth.support.google.dto.GoogleUserResponse;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
@@ -72,14 +73,14 @@ public class GoogleConnector {
         validateResponseStatusOk(responseEntity.getStatusCode());
 
         GoogleTokenResponse response = Optional.ofNullable(responseEntity.getBody())
-                .orElseThrow(() -> new MomoException(GlobalErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY));
+                .orElseThrow(() -> new MomoException(AuthErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY));
 
         return response.getAccessToken();
     }
 
     private void validateResponseStatusOk(HttpStatus status) {
         if (!status.is2xxSuccessful()) {
-            throw new MomoException(GlobalErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_2XX_STATUS);
+            throw new MomoException(AuthErrorCode.OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_2XX_STATUS);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/category/domain/Category.java
+++ b/backend/src/main/java/com/woowacourse/momo/category/domain/Category.java
@@ -7,8 +7,6 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.category.exception.CategoryErrorCode;
 import com.woowacourse.momo.category.exception.CategoryException;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 
 @Getter
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/woowacourse/momo/category/domain/Category.java
+++ b/backend/src/main/java/com/woowacourse/momo/category/domain/Category.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import com.woowacourse.momo.category.exception.CategoryErrorCode;
+import com.woowacourse.momo.category.exception.CategoryException;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
@@ -30,6 +32,6 @@ public enum Category {
         return Arrays.stream(values())
                 .filter(category -> category.id == id)
                 .findFirst()
-                .orElseThrow(() -> new MomoException(GlobalErrorCode.CATEGORY_NOT_EXIST));
+                .orElseThrow(() -> new CategoryException(CategoryErrorCode.CATEGORY_NOT_EXIST));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
 
 public enum CategoryErrorCode implements ErrorCode {
+
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND.value(), "CATEGORY_001", "존재하지 않는 카테고리입니다."),
     ;
 
@@ -17,7 +18,6 @@ public enum CategoryErrorCode implements ErrorCode {
         this.errorCode = errorCode;
         this.message = message;
     }
-
 
     @Override
     public int getStatusCode() {

--- a/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryErrorCode.java
@@ -1,0 +1,36 @@
+package com.woowacourse.momo.category.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+
+public enum CategoryErrorCode implements ErrorCode {
+    CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND.value(), "CATEGORY_001", "존재하지 않는 카테고리입니다."),
+    ;
+
+    private final int statusCode;
+    private final String errorCode;
+    private final String message;
+
+    CategoryErrorCode(int statusCode, String errorCode, String message) {
+        this.statusCode = statusCode;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+
+    @Override
+    public int getStatusCode() {
+        return 0;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryException.java
+++ b/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryException.java
@@ -3,6 +3,7 @@ package com.woowacourse.momo.category.exception;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
 public class CategoryException extends MomoException {
+
     public CategoryException(CategoryErrorCode code) {
         super(code);
     }

--- a/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryException.java
+++ b/backend/src/main/java/com/woowacourse/momo/category/exception/CategoryException.java
@@ -1,0 +1,9 @@
+package com.woowacourse.momo.category.exception;
+
+import com.woowacourse.momo.global.exception.exception.MomoException;
+
+public class CategoryException extends MomoException {
+    public CategoryException(CategoryErrorCode code) {
+        super(code);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -12,21 +12,6 @@ public enum GlobalErrorCode implements ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR_001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER_ERROR_001", "내부 서버 오류입니다."),
 
-
-    AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_001", "토큰의 유효기간이 만료되었습니다."),
-    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_002", "토큰이 유효하지 않습니다."),
-    AUTH_REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_003", "로그인이 필요합니다."),
-    AUTH_DELETE_NO_HOST(HttpStatus.FORBIDDEN.value(), "AUTH_ERROR_004", "주최자가 아닌 사람은 모임을 수정하거나 삭제할 수 없습니다."),
-
-    OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_2XX_STATUS(HttpStatus.INTERNAL_SERVER_ERROR.value(), "OAUTH_ERROR_001", "구글에 전송한 Access 토큰 요청이 실패했습니다."),
-    OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY(HttpStatus.INTERNAL_SERVER_ERROR.value(), "OAUTH_ERROR_001", "구글에 요청한 Access 토큰에 대하여 응답 Body가 비어 있습니다."),
-    OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS(HttpStatus.INTERNAL_SERVER_ERROR.value(), "OAUTH_ERROR_001", "구글에 전송한 회원정보 요청이 실패했습니다."),
-    OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY(HttpStatus.INTERNAL_SERVER_ERROR.value(), "OAUTH_ERROR_001", "구글에 요청한 회원정보에 대하여 응답 Body가 비어 있습니다."),
-
-    SIGNUP_INVALID_ID(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_001", "잘못된 형식의 아이디입니다."),
-    SIGNUP_INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_002", "잘못된 형식의 비밀번호입니다."),
-    SIGNUP_ALREADY_REGISTER(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_003", "이미 가입된 아이디입니다."),
-
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND.value(), "CATEGORY_ERROR_001", "존재하지 않는 카테고리입니다."),
 
     FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST.value(), "FILE_ERROR_001", "저장할 수 없는 확장자입니다."),

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -12,8 +12,6 @@ public enum GlobalErrorCode implements ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR_001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER_ERROR_001", "내부 서버 오류입니다."),
 
-    CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND.value(), "CATEGORY_ERROR_001", "존재하지 않는 카테고리입니다."),
-
     FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST.value(), "FILE_ERROR_001", "저장할 수 없는 확장자입니다."),
     FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "FILE_ERROR_002", "파일 입출력 에러입니다."),
     ;

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -12,17 +12,6 @@ public enum GlobalErrorCode implements ErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR_001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER_ERROR_001", "내부 서버 오류입니다."),
 
-    MEMBER_NOT_EXIST(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_001", "멤버가 존재하지 않습니다."),
-    MEMBER_DELETED(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_002", "탈퇴한 멤버입니다."),
-    MEMBER_DELETED_EXIST_IN_PROGRESS_GROUP(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_003", "진행중인 모임이 있어 탈퇴할 수 없습니다."),
-    MEMBER_WRONG_PASSWORD(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_004", "비밀번호가 일치하지 않습니다."),
-    MEMBER_NAME_SHOULD_NOT_BE_BLANK(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_005", "사용자의 이름이 빈 값입니다."),
-    MEMBER_NAME_MUST_BE_VALID(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_006", "사용자의 이름이 30자를 넘습니다."),
-    MEMBER_PASSWORD_SHOULD_NOT_BE_BLANK(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_007", "패스워드가 빈 값입니다."),
-    MEMBER_PASSWORD_PATTERN_MUST_BE_VALID(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_008", "패스워드는 영문자와 하나 이상의 숫자, 특수 문자를 갖고 있어야 합니다."),
-    MEMBER_ENCRYPTED_PASSWORD_MUST_NOT_UPDATE(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_009", "암호화된 패스워드는 수정할 수 없습니다."),
-    MEMBER_ID_SHOULD_NOT_BE_BLANK(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_010", "사용자의 아이디가 빈 값입니다."),
-    GOOGLE_ID_SHOULD_BE_IN_EMAIL_FORMAT(HttpStatus.BAD_REQUEST.value(), "MEMBER_ERROR_011", "구글 아이디가 이메일 형식이 아닙니다."),
 
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_001", "토큰의 유효기간이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "AUTH_ERROR_002", "토큰이 유효하지 않습니다."),
@@ -37,8 +26,6 @@ public enum GlobalErrorCode implements ErrorCode {
     SIGNUP_INVALID_ID(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_001", "잘못된 형식의 아이디입니다."),
     SIGNUP_INVALID_PASSWORD(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_002", "잘못된 형식의 비밀번호입니다."),
     SIGNUP_ALREADY_REGISTER(HttpStatus.BAD_REQUEST.value(), "SIGNUP_ERROR_003", "이미 가입된 아이디입니다."),
-
-    LOGIN_INVALID_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST.value(), "LOGIN_ERROR_001", "아이디나 비밀번호가 다릅니다."),
 
     CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND.value(), "CATEGORY_ERROR_001", "존재하지 않는 카테고리입니다."),
 

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -1,7 +1,5 @@
 package com.woowacourse.momo.global.exception.exception;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -9,11 +9,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
 
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "VALIDATION_ERROR_001", "잘못된 요청입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "SERVER_ERROR_001", "내부 서버 오류입니다."),
-
-    FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST.value(), "FILE_ERROR_001", "저장할 수 없는 확장자입니다."),
-    FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "FILE_ERROR_002", "파일 입출력 에러입니다."),
+    VALIDATION_ERROR(400, "VALIDATION_001", "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(500, "SERVER_001", "내부 서버 오류입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/group/controller/GroupModifyController.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/controller/GroupModifyController.java
@@ -50,7 +50,7 @@ public class GroupModifyController {
 
     @PutMapping("/{groupId}/location")
     public ResponseEntity<Void> updateLocation(@AuthenticationPrincipal Long memberId, @PathVariable Long groupId,
-                                       @RequestBody @Valid LocationUpdateApiRequest request) {
+                                               @RequestBody @Valid LocationUpdateApiRequest request) {
         groupModifyService.updateLocation(memberId, groupId, assembler.groupLocationUpdateRequest(request));
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -2,7 +2,6 @@ package com.woowacourse.momo.group.domain;
 
 import static com.woowacourse.momo.group.exception.GroupErrorCode.ALREADY_CLOSED_EARLY;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.ALREADY_DEADLINE_OVER;
-import static com.woowacourse.momo.group.exception.GroupErrorCode.PARTICIPANT_EXIST;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Deadline.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Deadline.java
@@ -1,6 +1,6 @@
 package com.woowacourse.momo.group.domain.calendar;
 
-import static com.woowacourse.momo.group.exception.GroupErrorCode.DEADLINE_NOT_PAST;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.DEADLINE_MUST_BE_SET_FROM_NOW_ON;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -42,7 +42,7 @@ public class Deadline {
 
     private void validateDeadlineIsAfterNow(LocalDateTime value) {
         if (isBeforeThanNow(value)) {
-            throw new GroupException(DEADLINE_NOT_PAST);
+            throw new GroupException(DEADLINE_MUST_BE_SET_FROM_NOW_ON);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Deadline.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Deadline.java
@@ -1,6 +1,6 @@
 package com.woowacourse.momo.group.domain.calendar;
 
-import static com.woowacourse.momo.group.exception.GroupErrorCode.DEADLINE_MUST_BE_SET_FROM_NOW_ON;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.DEADLINE_NOT_PAST;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -42,7 +42,7 @@ public class Deadline {
 
     private void validateDeadlineIsAfterNow(LocalDateTime value) {
         if (isBeforeThanNow(value)) {
-            throw new GroupException(DEADLINE_MUST_BE_SET_FROM_NOW_ON);
+            throw new GroupException(DEADLINE_NOT_PAST);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Duration.java
@@ -1,6 +1,6 @@
 package com.woowacourse.momo.group.domain.calendar;
 
-import static com.woowacourse.momo.group.exception.GroupErrorCode.DURATION_NOT_PAST;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.DURATION_MUST_BE_SET_FROM_NOW_ON;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.DURATION_START_DATE_MUST_BE_BEFORE_END_DATE;
 
 import java.time.LocalDate;
@@ -53,7 +53,7 @@ public class Duration {
 
     private void validateDatesAreNotPast(LocalDate startDate, LocalDate endDate) {
         if (hasAnyDatesBeforeThanNow(startDate, endDate)) {
-            throw new GroupException(DURATION_NOT_PAST);
+            throw new GroupException(DURATION_MUST_BE_SET_FROM_NOW_ON);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Duration.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/calendar/Duration.java
@@ -1,6 +1,6 @@
 package com.woowacourse.momo.group.domain.calendar;
 
-import static com.woowacourse.momo.group.exception.GroupErrorCode.DURATION_MUST_BE_SET_FROM_NOW_ON;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.DURATION_NOT_PAST;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.DURATION_START_DATE_MUST_BE_BEFORE_END_DATE;
 
 import java.time.LocalDate;
@@ -53,7 +53,7 @@ public class Duration {
 
     private void validateDatesAreNotPast(LocalDate startDate, LocalDate endDate) {
         if (hasAnyDatesBeforeThanNow(startDate, endDate)) {
-            throw new GroupException(DURATION_MUST_BE_SET_FROM_NOW_ON);
+            throw new GroupException(DURATION_NOT_PAST);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
@@ -1,6 +1,6 @@
 package com.woowacourse.momo.group.domain.participant;
 
-import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_OUT_OF_RANGE;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_CANNOT_BE_OUT_OF_RANGE;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -41,7 +41,7 @@ public class Capacity {
 
     private void validateCapacityIsInRange(int value) {
         if (isOutOfRange(value)) {
-            throw new GroupException(CAPACITY_OUT_OF_RANGE);
+            throw new GroupException(CAPACITY_CANNOT_BE_OUT_OF_RANGE);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
@@ -1,6 +1,6 @@
 package com.woowacourse.momo.group.domain.participant;
 
-import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_CANNOT_BE_OUT_OF_RANGE;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_OUT_OF_RANGE;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -41,7 +41,7 @@ public class Capacity {
 
     private void validateCapacityIsInRange(int value) {
         if (isOutOfRange(value)) {
-            throw new GroupException(CAPACITY_CANNOT_BE_OUT_OF_RANGE);
+            throw new GroupException(CAPACITY_OUT_OF_RANGE);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
@@ -1,7 +1,7 @@
 package com.woowacourse.momo.group.domain.participant;
 
 import static com.woowacourse.momo.group.exception.GroupErrorCode.ALREADY_PARTICIPANTS_SIZE_FULL;
-import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_CANNOT_BE_LESS_THAN_PARTICIPANTS_SIZE;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_LESS_THAN_PARTICIPANTS_SIZE;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.MEMBER_IS_HOST;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.MEMBER_IS_NOT_PARTICIPANT;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.MEMBER_IS_PARTICIPANT;
@@ -107,7 +107,7 @@ public class Participants {
 
     private void validateCapacityIsOverParticipantsSize(Capacity capacity) {
         if (capacity.isSmallThan(getSize())) {
-            throw new GroupException(CAPACITY_CANNOT_BE_LESS_THAN_PARTICIPANTS_SIZE);
+            throw new GroupException(CAPACITY_LESS_THAN_PARTICIPANTS_SIZE);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
@@ -1,7 +1,7 @@
 package com.woowacourse.momo.group.domain.participant;
 
 import static com.woowacourse.momo.group.exception.GroupErrorCode.ALREADY_PARTICIPANTS_SIZE_FULL;
-import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_LESS_THAN_PARTICIPANTS_SIZE;
+import static com.woowacourse.momo.group.exception.GroupErrorCode.CAPACITY_CANNOT_BE_LESS_THAN_PARTICIPANTS_SIZE;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.MEMBER_IS_HOST;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.MEMBER_IS_NOT_PARTICIPANT;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.MEMBER_IS_PARTICIPANT;
@@ -107,7 +107,7 @@ public class Participants {
 
     private void validateCapacityIsOverParticipantsSize(Capacity capacity) {
         if (capacity.isSmallThan(getSize())) {
-            throw new GroupException(CAPACITY_LESS_THAN_PARTICIPANTS_SIZE);
+            throw new GroupException(CAPACITY_CANNOT_BE_LESS_THAN_PARTICIPANTS_SIZE);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/group/exception/GroupErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/exception/GroupErrorCode.java
@@ -9,35 +9,35 @@ import com.woowacourse.momo.global.exception.exception.ErrorCode;
 @AllArgsConstructor
 public enum GroupErrorCode implements ErrorCode {
 
-    NOT_EXIST(404, "GROUP_ERROR_001", "존재하지 않는 모임입니다."),
+    NOT_EXIST(404, "GROUP_001", "존재하지 않는 모임입니다."),
 
-    DEADLINE_MUST_BE_SET_FROM_NOW_ON(400, "GROUP_ERROR_002", "마감시간이 과거일 수 없습니다."),
+    DEADLINE_NOT_PAST(400, "GROUP_002", "마감시간이 과거일 수 없습니다."),
 
-    DURATION_START_DATE_MUST_BE_BEFORE_END_DATE(400, "GROUP_ERROR_003", "기간의 시작일은 종료일 이전이어야 합니다."),
-    DURATION_MUST_BE_SET_FROM_NOW_ON(400, "GROUP_ERROR_004", "시작일과 종료일은 과거일 수 없습니다."),
-    DURATION_MUST_BE_SET_BEFORE_DEADLINE(400, "GROUP_ERROR_005", "마감시간이 시작 일자 이후일 수 없습니다."),
+    DURATION_START_DATE_MUST_BE_BEFORE_END_DATE(400, "GROUP_003", "기간의 시작일은 종료일 이전이어야 합니다."),
+    DURATION_NOT_PAST(400, "GROUP_004", "시작일과 종료일은 과거일 수 없습니다."),
+    DURATION_MUST_BE_SET_BEFORE_DEADLINE(400, "GROUP_005", "마감시간이 시작 일자 이후일 수 없습니다."),
 
-    SCHEDULE_START_TIME_MUST_BE_BEFORE_END_TIME(400, "GROUP_ERROR_006", "일정의 시작 시간은 종료 시간 이전이어야 합니다."),
-    SCHEDULE_MUST_BE_INCLUDED_IN_DURATION(400, "GROUP_ERROR_007", "일정은 모임 기간에 포함되어야 합니다."),
+    SCHEDULE_START_TIME_MUST_BE_BEFORE_END_TIME(400, "GROUP_006", "일정의 시작 시간은 종료 시간 이전이어야 합니다."),
+    SCHEDULE_MUST_BE_INCLUDED_IN_DURATION(400, "GROUP_007", "일정은 모임 기간에 포함되어야 합니다."),
 
-    NAME_CANNOT_BE_BLANK(400, "GROUP_ERROR_008", "모임의 이름은 빈 값이 될 수 없습니다."),
+    NAME_CANNOT_BE_BLANK(400, "GROUP_008", "모임의 이름은 빈 값이 될 수 없습니다."),
 
-    CAPACITY_CANNOT_BE_OUT_OF_RANGE(400, "GROUP_ERROR_009", "모임 내 인원은 1명 이상 99명 이하여야 합니다."),
-    CAPACITY_CANNOT_BE_LESS_THAN_PARTICIPANTS_SIZE(400, "GROUP_ERROR_010", "참가인원제한은 현재 참가자의 인원수보다 적을 수 없습니다."),
+    CAPACITY_OUT_OF_RANGE(400, "GROUP_009", "모임 내 인원은 1명 이상 99명 이하여야 합니다."),
+    CAPACITY_LESS_THAN_PARTICIPANTS_SIZE(400, "GROUP_010", "참가인원제한은 현재 참가자의 인원수보다 적을 수 없습니다."),
 
-    ALREADY_CLOSED_EARLY(400, "GROUP_ERROR_011", "해당 모임은 조기 마감되어 있습니다."),
-    ALREADY_DEADLINE_OVER(400, "GROUP_ERROR_012", "해당 모임은 마감기한이 지났습니다."),
-    ALREADY_PARTICIPANTS_SIZE_FULL(400, "GROUP_ERROR_013", "참여인원이 가득 찼습니다."),
+    ALREADY_CLOSED_EARLY(400, "GROUP_011", "해당 모임은 조기 마감되어 있습니다."),
+    ALREADY_DEADLINE_OVER(400, "GROUP_012", "해당 모임은 마감기한이 지났습니다."),
+    ALREADY_PARTICIPANTS_SIZE_FULL(400, "GROUP_013", "참여인원이 가득 찼습니다."),
 
-    PARTICIPANT_EXIST(400, "GROUP_ERROR_014", "해당 모임은 참여자가 존재합니다."),
+    PARTICIPANT_EXIST(400, "GROUP_014", "해당 모임은 참여자가 존재합니다."),
 
-    MEMBER_IS_HOST(400, "GROUP_ERROR_015", "해당 모임의 주최자입니다."),
-    MEMBER_IS_PARTICIPANT(400, "GROUP_ERROR_016", "해당 모임의 참여자입니다."),
-    MEMBER_IS_NOT_HOST(403, "GROUP_ERROR_017", "해당 모임의 주최자가 아닙니다."),
-    MEMBER_IS_NOT_PARTICIPANT(403, "GROUP_ERROR_018", "해당 모임의 참여자가 아닙니다."),
+    MEMBER_IS_HOST(400, "GROUP_015", "해당 모임의 주최자입니다."),
+    MEMBER_IS_PARTICIPANT(400, "GROUP_016", "해당 모임의 참여자입니다."),
+    MEMBER_IS_NOT_HOST(403, "GROUP_017", "해당 모임의 주최자가 아닙니다."),
+    MEMBER_IS_NOT_PARTICIPANT(403, "GROUP_018", "해당 모임의 참여자가 아닙니다."),
 
-    MEMBER_ALREADY_LIKE(400, "GROUP_ERROR_019", "이미 찜한 모임입니다."),
-    MEMBER_NOT_YET_LIKE(403, "GROUP_ERROR_020", "찜하지 않은 모임입니다."),
+    MEMBER_ALREADY_LIKE(400, "GROUP_019", "이미 찜한 모임입니다."),
+    MEMBER_NOT_YET_LIKE(403, "GROUP_020", "찜하지 않은 모임입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/group/exception/GroupErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/exception/GroupErrorCode.java
@@ -11,10 +11,10 @@ public enum GroupErrorCode implements ErrorCode {
 
     NOT_EXIST(404, "GROUP_001", "존재하지 않는 모임입니다."),
 
-    DEADLINE_NOT_PAST(400, "GROUP_002", "마감시간이 과거일 수 없습니다."),
+    DEADLINE_MUST_BE_SET_FROM_NOW_ON(400, "GROUP_002", "마감시간이 과거일 수 없습니다."),
 
     DURATION_START_DATE_MUST_BE_BEFORE_END_DATE(400, "GROUP_003", "기간의 시작일은 종료일 이전이어야 합니다."),
-    DURATION_NOT_PAST(400, "GROUP_004", "시작일과 종료일은 과거일 수 없습니다."),
+    DURATION_MUST_BE_SET_FROM_NOW_ON(400, "GROUP_004", "시작일과 종료일은 과거일 수 없습니다."),
     DURATION_MUST_BE_SET_BEFORE_DEADLINE(400, "GROUP_005", "마감시간이 시작 일자 이후일 수 없습니다."),
 
     SCHEDULE_START_TIME_MUST_BE_BEFORE_END_TIME(400, "GROUP_006", "일정의 시작 시간은 종료 시간 이전이어야 합니다."),
@@ -22,8 +22,8 @@ public enum GroupErrorCode implements ErrorCode {
 
     NAME_CANNOT_BE_BLANK(400, "GROUP_008", "모임의 이름은 빈 값이 될 수 없습니다."),
 
-    CAPACITY_OUT_OF_RANGE(400, "GROUP_009", "모임 내 인원은 1명 이상 99명 이하여야 합니다."),
-    CAPACITY_LESS_THAN_PARTICIPANTS_SIZE(400, "GROUP_010", "참가인원제한은 현재 참가자의 인원수보다 적을 수 없습니다."),
+    CAPACITY_CANNOT_BE_OUT_OF_RANGE(400, "GROUP_009", "모임 내 인원은 1명 이상 99명 이하여야 합니다."),
+    CAPACITY_CANNOT_BE_LESS_THAN_PARTICIPANTS_SIZE(400, "GROUP_010", "참가인원제한은 현재 참가자의 인원수보다 적을 수 없습니다."),
 
     ALREADY_CLOSED_EARLY(400, "GROUP_011", "해당 모임은 조기 마감되어 있습니다."),
     ALREADY_DEADLINE_OVER(400, "GROUP_012", "해당 모임은 마감기한이 지났습니다."),

--- a/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
@@ -16,10 +16,10 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.config.Authenticated;
 import com.woowacourse.momo.auth.config.AuthenticationPrincipal;
-import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.member.service.MemberService;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.member.service.dto.response.MyInfoResponse;
 
 @RequiredArgsConstructor
@@ -43,6 +43,7 @@ public class MemberController {
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
     @PatchMapping("/name")
     public ResponseEntity<Void> updateName(@AuthenticationPrincipal Long id,
                                            @RequestBody @Valid ChangeNameRequest request) {

--- a/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/controller/MemberController.java
@@ -2,10 +2,12 @@ package com.woowacourse.momo.member.controller;
 
 import javax.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.config.Authenticated;
 import com.woowacourse.momo.auth.config.AuthenticationPrincipal;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.member.service.MemberService;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
@@ -34,6 +37,12 @@ public class MemberController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping
+    public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
+        memberService.signUp(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
     @PatchMapping("/name")
     public ResponseEntity<Void> updateName(@AuthenticationPrincipal Long id,
                                            @RequestBody @Valid ChangeNameRequest request) {

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/Password.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/Password.java
@@ -10,8 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.woowacourse.momo.auth.support.PasswordEncoder;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.exception.MemberErrorCode;
 import com.woowacourse.momo.member.exception.MemberException;
 

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/Password.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/Password.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.member.exception.MemberErrorCode;
+import com.woowacourse.momo.member.exception.MemberException;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -55,13 +57,13 @@ public class Password {
 
     private static void validatePasswordIsNotBlank(String value) {
         if (value.isBlank()) {
-            throw new MomoException(GlobalErrorCode.MEMBER_PASSWORD_SHOULD_NOT_BE_BLANK);
+            throw new MemberException(MemberErrorCode.MEMBER_PASSWORD_SHOULD_NOT_BE_BLANK);
         }
     }
 
     private static void validatePasswordPatternIsValid(String value) {
         if (isNotValid(value)) {
-            throw new MomoException(GlobalErrorCode.MEMBER_PASSWORD_PATTERN_MUST_BE_VALID);
+            throw new MemberException(MemberErrorCode.MEMBER_PASSWORD_PATTERN_MUST_BE_VALID);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/UserId.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/UserId.java
@@ -11,6 +11,8 @@ import lombok.ToString;
 
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.member.exception.MemberErrorCode;
+import com.woowacourse.momo.member.exception.MemberException;
 
 @ToString(includeFieldNames = false)
 @EqualsAndHashCode
@@ -45,7 +47,7 @@ public class UserId {
 
     private static void validateUserIdIsNotBlank(String value) {
         if (value.isBlank()) {
-            throw new MomoException(GlobalErrorCode.MEMBER_ID_SHOULD_NOT_BE_BLANK);
+            throw new MemberException(MemberErrorCode.MEMBER_ID_SHOULD_NOT_BE_BLANK);
         }
     }
 
@@ -57,7 +59,7 @@ public class UserId {
 
     private static void validateUserEmailIsValidPattern(String value) {
         if (!value.contains(EMAIL_FORMAT)) {
-            throw new MomoException(GlobalErrorCode.GOOGLE_ID_SHOULD_BE_IN_EMAIL_FORMAT);
+            throw new MemberException(MemberErrorCode.GOOGLE_ID_SHOULD_BE_IN_EMAIL_FORMAT);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/UserId.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/UserId.java
@@ -9,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.exception.MemberErrorCode;
@@ -53,7 +55,7 @@ public class UserId {
 
     private static void validateUserIdIsValidPattern(String value) {
         if (value.contains(EMAIL_FORMAT)) {
-            throw new MomoException(GlobalErrorCode.SIGNUP_INVALID_ID);
+            throw new MemberException(MemberErrorCode.SIGNUP_INVALID_ID);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/UserId.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/UserId.java
@@ -9,10 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import com.woowacourse.momo.auth.exception.AuthErrorCode;
-import com.woowacourse.momo.auth.exception.AuthException;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.exception.MemberErrorCode;
 import com.woowacourse.momo.member.exception.MemberException;
 

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/UserName.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/UserName.java
@@ -9,8 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.exception.MemberErrorCode;
 import com.woowacourse.momo.member.exception.MemberException;
 

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/UserName.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/UserName.java
@@ -11,6 +11,8 @@ import lombok.ToString;
 
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.member.exception.MemberErrorCode;
+import com.woowacourse.momo.member.exception.MemberException;
 
 @ToString(includeFieldNames = false)
 @EqualsAndHashCode
@@ -44,13 +46,13 @@ public class UserName {
 
     private static void validateNameIsNotBlank(String value) {
         if (value.isBlank()) {
-            throw new MomoException(GlobalErrorCode.MEMBER_NAME_SHOULD_NOT_BE_BLANK);
+            throw new MemberException(MemberErrorCode.MEMBER_NAME_SHOULD_NOT_BE_BLANK);
         }
     }
 
     private static void validateNameLengthIsValid(String value) {
         if (value.length() > MAXIMUM) {
-            throw new MomoException(GlobalErrorCode.MEMBER_NAME_MUST_BE_VALID);
+            throw new MemberException(MemberErrorCode.MEMBER_NAME_MUST_BE_VALID);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
@@ -1,10 +1,9 @@
 package com.woowacourse.momo.member.exception;
 
-import org.springframework.http.HttpStatus;
-
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
 
 public enum MemberErrorCode implements ErrorCode {
+
     MEMBER_NOT_EXIST(400, "MEMBER_001", "멤버가 존재하지 않습니다."),
     MEMBER_DELETED(400, "MEMBER_002", "탈퇴한 멤버입니다."),
     MEMBER_DELETED_EXIST_IN_PROGRESS_GROUP(400, "MEMBER_003", "진행중인 모임이 있어 탈퇴할 수 없습니다."),

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
@@ -18,7 +18,11 @@ public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_ID_SHOULD_NOT_BE_BLANK(400, "MEMBER_010", "사용자의 아이디가 빈 값입니다."),
     GOOGLE_ID_SHOULD_BE_IN_EMAIL_FORMAT(400, "MEMBER_011", "구글 아이디가 이메일 형식이 아닙니다."),
-    MEMBER_INVALID_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST.value(), "MEMBER_012", "아이디나 비밀번호가 다릅니다."),
+    MEMBER_INVALID_ID_AND_PASSWORD(400, "MEMBER_012", "아이디나 비밀번호가 다릅니다."),
+
+    SIGNUP_INVALID_ID(400, "SIGNUP_001", "잘못된 형식의 아이디입니다."),
+    SIGNUP_INVALID_PASSWORD(400, "SIGNUP_002", "잘못된 형식의 비밀번호입니다."),
+    SIGNUP_ALREADY_REGISTER(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
     ;
 
     private final int statusCode;
@@ -33,16 +37,16 @@ public enum MemberErrorCode implements ErrorCode {
 
     @Override
     public int getStatusCode() {
-        return 0;
+        return statusCode;
     }
 
     @Override
     public String getErrorCode() {
-        return null;
+        return errorCode;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return message;
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
@@ -1,0 +1,48 @@
+package com.woowacourse.momo.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+
+public enum MemberErrorCode implements ErrorCode {
+    MEMBER_NOT_EXIST(400, "MEMBER_001", "멤버가 존재하지 않습니다."),
+    MEMBER_DELETED(400, "MEMBER_002", "탈퇴한 멤버입니다."),
+    MEMBER_DELETED_EXIST_IN_PROGRESS_GROUP(400, "MEMBER_003", "진행중인 모임이 있어 탈퇴할 수 없습니다."),
+    MEMBER_WRONG_PASSWORD(400, "MEMBER_004", "비밀번호가 일치하지 않습니다."),
+
+    MEMBER_NAME_SHOULD_NOT_BE_BLANK(400, "MEMBER_005", "사용자의 이름이 빈 값입니다."),
+    MEMBER_NAME_MUST_BE_VALID(400, "MEMBER_006", "사용자의 이름이 30자를 넘습니다."),
+
+    MEMBER_PASSWORD_SHOULD_NOT_BE_BLANK(400, "MEMBER_007", "패스워드가 빈 값입니다."),
+    MEMBER_PASSWORD_PATTERN_MUST_BE_VALID(400, "MEMBER_008", "패스워드는 영문자와 하나 이상의 숫자, 특수 문자를 갖고 있어야 합니다."),
+
+    MEMBER_ID_SHOULD_NOT_BE_BLANK(400, "MEMBER_010", "사용자의 아이디가 빈 값입니다."),
+    GOOGLE_ID_SHOULD_BE_IN_EMAIL_FORMAT(400, "MEMBER_011", "구글 아이디가 이메일 형식이 아닙니다."),
+    MEMBER_INVALID_ID_AND_PASSWORD(HttpStatus.BAD_REQUEST.value(), "MEMBER_012", "아이디나 비밀번호가 다릅니다."),
+    ;
+
+    private final int statusCode;
+    private final String errorCode;
+    private final String message;
+
+    MemberErrorCode(int statusCode, String errorCode, String message) {
+        this.statusCode = statusCode;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 0;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberException.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package com.woowacourse.momo.member.exception;
+
+import com.woowacourse.momo.global.exception.exception.MomoException;
+
+public class MemberException extends MomoException {
+
+    public MemberException(MemberErrorCode code) {
+        super(code);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberException.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberException.java
@@ -4,6 +4,7 @@ import com.woowacourse.momo.global.exception.exception.MomoException;
 
 public class MemberException extends MomoException {
 
+
     public MemberException(MemberErrorCode code) {
         super(code);
     }

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberException.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberException.java
@@ -4,7 +4,6 @@ import com.woowacourse.momo.global.exception.exception.MomoException;
 
 public class MemberException extends MomoException {
 
-
     public MemberException(MemberErrorCode code) {
         super(code);
     }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
@@ -37,7 +37,7 @@ public class MemberFindService {
 
     private void validateExistMember(Member member) {
         if (member.isDeleted()) {
-            throw new MomoException(MemberErrorCode.MEMBER_DELETED);
+            throw new MemberException(MemberErrorCode.MEMBER_DELETED);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
@@ -5,8 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.domain.Password;

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberFindService.java
@@ -11,6 +11,8 @@ import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.domain.Password;
 import com.woowacourse.momo.member.domain.UserId;
+import com.woowacourse.momo.member.exception.MemberErrorCode;
+import com.woowacourse.momo.member.exception.MemberException;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,21 +23,21 @@ public class MemberFindService {
 
     public Member findMember(Long id) {
         Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new MomoException(GlobalErrorCode.MEMBER_NOT_EXIST));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_EXIST));
         validateExistMember(member);
         return member;
     }
 
     public Member findByUserIdAndPassword(UserId userId, Password password) {
         Member member = memberRepository.findByUserIdAndPassword(userId, password)
-                .orElseThrow(() -> new MomoException(GlobalErrorCode.LOGIN_INVALID_ID_AND_PASSWORD));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_INVALID_ID_AND_PASSWORD));
         validateExistMember(member);
         return member;
     }
 
     private void validateExistMember(Member member) {
         if (member.isDeleted()) {
-            throw new MomoException(GlobalErrorCode.MEMBER_DELETED);
+            throw new MomoException(MemberErrorCode.MEMBER_DELETED);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.woowacourse.momo.member.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -9,12 +10,18 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.domain.TokenRepository;
+import com.woowacourse.momo.auth.exception.AuthErrorCode;
+import com.woowacourse.momo.auth.exception.AuthException;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.Group;
 import com.woowacourse.momo.group.service.GroupFindService;
 import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.member.domain.MemberRepository;
+import com.woowacourse.momo.member.domain.Password;
+import com.woowacourse.momo.member.domain.UserId;
+import com.woowacourse.momo.member.domain.UserName;
 import com.woowacourse.momo.member.exception.MemberErrorCode;
 import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
@@ -27,10 +34,31 @@ import com.woowacourse.momo.member.service.dto.response.MyInfoResponse;
 @Service
 public class MemberService {
 
+    private final MemberRepository memberRepository;
     private final MemberFindService memberFindService;
     private final PasswordEncoder passwordEncoder;
     private final GroupFindService groupFindService;
     private final TokenRepository tokenRepository;
+
+    @Transactional
+    public Long signUp(SignUpRequest request) {
+        UserId userId = UserId.momo(request.getUserId());
+        UserName userName = UserName.from(request.getName());
+        Password password = Password.encrypt(request.getPassword(), passwordEncoder);
+        Member member = new Member(userId, password, userName);
+
+        validateUserIsNotExist(userId);
+        Member savedMember = memberRepository.save(member);
+
+        return savedMember.getId();
+    }
+
+    private void validateUserIsNotExist(UserId userId) {
+        Optional<Member> member = memberRepository.findByUserId(userId);
+        if (member.isPresent()) {
+            throw new AuthException(AuthErrorCode.SIGNUP_ALREADY_REGISTER);
+        }
+    }
 
     public MyInfoResponse findById(Long id) {
         Member member = memberFindService.findMember(id);

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -15,6 +15,7 @@ import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.Group;
 import com.woowacourse.momo.group.service.GroupFindService;
 import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.member.exception.MemberErrorCode;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
 import com.woowacourse.momo.member.service.dto.response.MemberResponseAssembler;
@@ -55,7 +56,7 @@ public class MemberService {
 
     private void validateMemberIsNotHost(Member member, List<Group> groups) {
         if (isHost(member, groups)) {
-            throw new MomoException(GlobalErrorCode.MEMBER_DELETED_EXIST_IN_PROGRESS_GROUP);
+            throw new MomoException(MemberErrorCode.MEMBER_DELETED_EXIST_IN_PROGRESS_GROUP);
         }
     }
 
@@ -82,7 +83,7 @@ public class MemberService {
     private void confirmPassword(Member member, String password) {
         String encryptedPassword = passwordEncoder.encrypt(password);
         if (member.isNotSamePassword(encryptedPassword)) {
-            throw new MomoException(GlobalErrorCode.MEMBER_WRONG_PASSWORD);
+            throw new MomoException(MemberErrorCode.MEMBER_WRONG_PASSWORD);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -16,6 +16,7 @@ import com.woowacourse.momo.group.domain.Group;
 import com.woowacourse.momo.group.service.GroupFindService;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.exception.MemberErrorCode;
+import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
 import com.woowacourse.momo.member.service.dto.response.MemberResponseAssembler;
@@ -83,7 +84,7 @@ public class MemberService {
     private void confirmPassword(Member member, String password) {
         String encryptedPassword = passwordEncoder.encrypt(password);
         if (member.isNotSamePassword(encryptedPassword)) {
-            throw new MomoException(MemberErrorCode.MEMBER_WRONG_PASSWORD);
+            throw new MemberException(MemberErrorCode.MEMBER_WRONG_PASSWORD);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import com.woowacourse.momo.auth.domain.TokenRepository;
 import com.woowacourse.momo.auth.exception.AuthErrorCode;
 import com.woowacourse.momo.auth.exception.AuthException;
-import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.Group;
@@ -26,6 +25,7 @@ import com.woowacourse.momo.member.exception.MemberErrorCode;
 import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.member.service.dto.response.MemberResponseAssembler;
 import com.woowacourse.momo.member.service.dto.response.MyInfoResponse;
 

--- a/backend/src/main/java/com/woowacourse/momo/member/service/dto/request/SignUpRequest.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/dto/request/SignUpRequest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.momo.auth.service.dto.request;
+package com.woowacourse.momo.member.service.dto.request;
 
 import javax.validation.constraints.NotNull;
 

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageErrorCode.java
@@ -1,23 +1,21 @@
-package com.woowacourse.momo.category.exception;
-
-import org.springframework.http.HttpStatus;
+package com.woowacourse.momo.storage.exception;
 
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
 
-public enum CategoryErrorCode implements ErrorCode {
-    CATEGORY_NOT_EXIST(HttpStatus.NOT_FOUND.value(), "CATEGORY_001", "존재하지 않는 카테고리입니다."),
+public enum StorageErrorCode implements ErrorCode {
+    FILE_INVALID_EXTENSION(400, "FILE_001", "저장할 수 없는 확장자입니다."),
+    FILE_IO_ERROR(500, "FILE_002", "파일 입출력 에러입니다."),
     ;
 
     private final int statusCode;
     private final String errorCode;
     private final String message;
 
-    CategoryErrorCode(int statusCode, String errorCode, String message) {
+    StorageErrorCode(int statusCode, String errorCode, String message) {
         this.statusCode = statusCode;
         this.errorCode = errorCode;
         this.message = message;
     }
-
 
     @Override
     public int getStatusCode() {

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageErrorCode.java
@@ -3,6 +3,7 @@ package com.woowacourse.momo.storage.exception;
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
 
 public enum StorageErrorCode implements ErrorCode {
+
     FILE_INVALID_EXTENSION(400, "FILE_001", "저장할 수 없는 확장자입니다."),
     FILE_IO_ERROR(500, "FILE_002", "파일 입출력 에러입니다."),
     ;

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageException.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageException.java
@@ -1,6 +1,5 @@
 package com.woowacourse.momo.storage.exception;
 
-import com.woowacourse.momo.global.exception.exception.ErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
 public class StorageException extends MomoException {

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageException.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/StorageException.java
@@ -1,0 +1,11 @@
+package com.woowacourse.momo.storage.exception;
+
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.MomoException;
+
+public class StorageException extends MomoException {
+
+    public StorageException(StorageErrorCode code) {
+        super(code);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -15,8 +15,6 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.storage.exception.StorageErrorCode;
 import com.woowacourse.momo.storage.exception.StorageException;
 

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/StorageService.java
@@ -17,6 +17,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.storage.exception.StorageErrorCode;
+import com.woowacourse.momo.storage.exception.StorageException;
 
 @Service
 public class StorageService {
@@ -35,7 +37,7 @@ public class StorageService {
         try (OutputStream outputStream = new FileOutputStream(savedFile)) {
             outputStream.write(requestFile.getBytes());
         } catch (IOException e) {
-            throw new MomoException(GlobalErrorCode.FILE_IO_ERROR);
+            throw new StorageException(StorageErrorCode.FILE_IO_ERROR);
         }
 
         return savedFile.getName();
@@ -45,7 +47,7 @@ public class StorageService {
         String contentType = file.getContentType();
 
         if (contentType == null || isContentTypeNotImage(contentType)) {
-            throw new MomoException(GlobalErrorCode.FILE_INVALID_EXTENSION);
+            throw new StorageException(StorageErrorCode.FILE_INVALID_EXTENSION);
         }
     }
 
@@ -61,7 +63,7 @@ public class StorageService {
             }
             temporary.createNewFile();
         } catch (IOException e) {
-            throw new MomoException(GlobalErrorCode.FILE_IO_ERROR);
+            throw new StorageException(StorageErrorCode.FILE_IO_ERROR);
         }
     }
 
@@ -70,7 +72,7 @@ public class StorageService {
         try (InputStream inputStream = new FileInputStream(file)) {
             return inputStream.readAllBytes();
         } catch (IOException e) {
-            throw new MomoException(GlobalErrorCode.FILE_IO_ERROR);
+            throw new StorageException(StorageErrorCode.FILE_IO_ERROR);
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/auth/AuthRestHandler.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/auth/AuthRestHandler.java
@@ -4,7 +4,7 @@ import io.restassured.response.ValidatableResponse;
 
 import com.woowacourse.momo.acceptance.RestHandler;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.fixture.MemberFixture;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -14,7 +14,7 @@ public class AuthRestHandler extends RestHandler {
 
     public static ValidatableResponse 회원가입을_한다(String userId, String password, String name) {
         SignUpRequest request = new SignUpRequest(userId, password, name);
-        return postRequest(request, BASE_URL + "/signup");
+        return postRequest(request, "api/members");
     }
 
     public static ValidatableResponse 회원가입을_한다(MemberFixture memberFixture) {

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupCreateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupCreateAcceptanceTest.java
@@ -30,6 +30,6 @@ class GroupCreateAcceptanceTest extends AcceptanceTest {
     void createGroupByNonMember() {
         모임을_생성한다(GROUP)
                 .statusCode(HttpStatus.UNAUTHORIZED.value())
-                .body("message", Matchers.is("AUTH_ERROR_003"));
+                .body("message", Matchers.is("AUTH_003"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupDeleteAcceptanceTest.java
@@ -39,7 +39,7 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
 
         모임을_조회한다(hostAccessToken, groupId)
                 .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", Matchers.is("GROUP_ERROR_001"));
+                .body("message", Matchers.is("GROUP_001"));
     }
 
     @DisplayName("주최자가 아닌 회원이 모임을 삭제한다")
@@ -49,7 +49,7 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
 
         모임을_삭제한다(anotherAccessToken, groupId)
                 .statusCode(HttpStatus.FORBIDDEN.value())
-                .body("message", Matchers.is("GROUP_ERROR_017"));
+                .body("message", Matchers.is("GROUP_017"));
 
         모임을_조회한다(hostAccessToken, groupId)
                 .statusCode(HttpStatus.OK.value());
@@ -60,7 +60,7 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
     void deleteGroupByNonMember() {
         모임을_삭제한다(groupId)
                 .statusCode(HttpStatus.UNAUTHORIZED.value())
-                .body("message", Matchers.is("AUTH_ERROR_003"));
+                .body("message", Matchers.is("AUTH_003"));
 
         모임을_조회한다(hostAccessToken, groupId)
                 .statusCode(HttpStatus.OK.value());
@@ -71,11 +71,11 @@ class GroupDeleteAcceptanceTest extends AcceptanceTest {
     void deleteNonExistentGroup() {
         모임을_조회한다(hostAccessToken, 0L)
                 .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", Matchers.is("GROUP_ERROR_001"));
+                .body("message", Matchers.is("GROUP_001"));
 
         모임을_삭제한다(hostAccessToken, 0L)
                 .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", Matchers.is("GROUP_ERROR_001"));
+                .body("message", Matchers.is("GROUP_001"));
     }
 
     @DisplayName("참여자가 있는 모임을 삭제한다")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupFindAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupFindAcceptanceTest.java
@@ -149,7 +149,7 @@ class GroupFindAcceptanceTest extends AcceptanceTest {
     void findNonExistentGroup() {
         모임을_조회한다(hostAccessToken, 0L)
                 .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", Matchers.is("GROUP_ERROR_001"));
+                .body("message", Matchers.is("GROUP_001"));
     }
 
     @DisplayName("모임목록중 첫번째 페이지를 조회한다")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/group/GroupUpdateAcceptanceTest.java
@@ -102,7 +102,7 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
 
         모임을_수정한다(anotherAccessToken, groupId, DUDU_STUDY)
                 .statusCode(HttpStatus.FORBIDDEN.value())
-                .body("message", Matchers.is("GROUP_ERROR_017"));
+                .body("message", Matchers.is("GROUP_017"));
     }
 
     @DisplayName("비회원이 모임을 수정한다")
@@ -110,7 +110,7 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
     void updateGroupByNonMember() {
         모임을_수정한다(groupId, DUDU_STUDY)
                 .statusCode(HttpStatus.UNAUTHORIZED.value())
-                .body("message", Matchers.is("AUTH_ERROR_003"));
+                .body("message", Matchers.is("AUTH_003"));
     }
 
     @DisplayName("존재하지 않은 모임을 삭제한다")
@@ -118,7 +118,7 @@ class GroupUpdateAcceptanceTest extends AcceptanceTest {
     void updateNonExistentGroup() {
         모임을_수정한다(hostAccessToken, 0L, DUDU_STUDY)
                 .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", Matchers.is("GROUP_ERROR_001"));
+                .body("message", Matchers.is("GROUP_001"));
     }
 
     @DisplayName("모임을 조기 마감한다")

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/member/MemberAcceptanceTest.java
@@ -73,7 +73,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
 
         AuthRestHandler.로그인을_한다(MEMBER.getUserId(), MEMBER.getPassword())
                 .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", Matchers.is("LOGIN_ERROR_001"));
+                .body("message", Matchers.is("MEMBER_012"));
     }
 
     @DisplayName("회원 탈퇴 시 참여한 모임 중 진행중인 모임이 있을 경우 모임에 탈퇴시킨다")
@@ -103,6 +103,6 @@ class MemberAcceptanceTest extends AcceptanceTest {
 
         MemberRestHandler.회원탈퇴를_한다(accessToken)
                 .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", Matchers.is("MEMBER_ERROR_003"));
+                .body("message", Matchers.is("MEMBER_003"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/acceptance/participant/ParticipantAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/acceptance/participant/ParticipantAcceptanceTest.java
@@ -61,7 +61,7 @@ class ParticipantAcceptanceTest extends AcceptanceTest {
 
         모임에_참여한다(accessToken, groupId)
                 .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", Matchers.is("GROUP_ERROR_016"));
+                .body("message", Matchers.is("GROUP_016"));
     }
 
     @DisplayName("존재하지 않은 모임에 참여한다")
@@ -69,14 +69,14 @@ class ParticipantAcceptanceTest extends AcceptanceTest {
     void participateToNonExistentGroup() {
         모임에_참여한다(hostAccessToken, 0L)
                 .statusCode(HttpStatus.NOT_FOUND.value())
-                .body("message", Matchers.is("GROUP_ERROR_001"));
+                .body("message", Matchers.is("GROUP_001"));
     }
 
     @DisplayName("비회원이 모임에 참여한다")
     @Test
     void participateByNonMember() {
         모임에_참여한다(groupId).statusCode(HttpStatus.UNAUTHORIZED.value())
-                .body("message", Matchers.is("AUTH_ERROR_003"));
+                .body("message", Matchers.is("AUTH_003"));
     }
 
     @DisplayName("정원이 가득 찬 모임에 참여한다")

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
@@ -23,9 +23,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import lombok.AllArgsConstructor;
+
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.MemberService;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 
 @AutoConfigureMockMvc
@@ -47,12 +50,15 @@ class AuthControllerTest {
     @Autowired
     private AuthService authService;
 
+    @Autowired
+    private MemberService memberService;
+
     @DisplayName("정상적으로 회원가입이 되는 경우를 테스트한다")
     @Test
     void signUp() throws Exception {
         SignUpRequest request = new SignUpRequest(USER_ID, PASSWORD, NAME);
 
-        mockMvc.perform(post("/api/auth/signup")
+        mockMvc.perform(post("/api/members")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 )
@@ -70,7 +76,7 @@ class AuthControllerTest {
     void signUpWithInvalidUserIdPattern() throws Exception {
         SignUpRequest request = new SignUpRequest("woowa@", PASSWORD, NAME);
 
-        mockMvc.perform(post("/api/auth/signup")
+        mockMvc.perform(post("/api/members")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
@@ -82,7 +88,7 @@ class AuthControllerTest {
     void signUpWithBlankUserId() throws Exception {
         SignUpRequest request = new SignUpRequest("", PASSWORD, NAME);
 
-        mockMvc.perform(post("/api/auth/signup")
+        mockMvc.perform(post("/api/members")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
@@ -94,7 +100,7 @@ class AuthControllerTest {
     void signUpWithBlankPassword() throws Exception {
         SignUpRequest request = new SignUpRequest(USER_ID, "", NAME);
 
-        mockMvc.perform(post("/api/auth/signup")
+        mockMvc.perform(post("/api/members")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
@@ -106,7 +112,7 @@ class AuthControllerTest {
     void signUpWithInvalidPasswordPattern() throws Exception {
         SignUpRequest request = new SignUpRequest(USER_ID, "woowa", NAME);
 
-        mockMvc.perform(post("/api/auth/signup")
+        mockMvc.perform(post("/api/members")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
@@ -118,7 +124,7 @@ class AuthControllerTest {
     void signUpWithBlankName() throws Exception {
         SignUpRequest request = new SignUpRequest("woowa", PASSWORD, "");
 
-        mockMvc.perform(post("/api/auth/signup")
+        mockMvc.perform(post("/api/members")
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
@@ -214,7 +220,7 @@ class AuthControllerTest {
 
     void saveMember(String userId, String password, String name) {
         SignUpRequest request = new SignUpRequest(userId, password, name);
-        authService.signUp(request);
+        memberService.signUp(request);
     }
 
     LoginResponse extractLoginResponse(String userId, String password) {

--- a/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/controller/AuthControllerTest.java
@@ -74,7 +74,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("SIGNUP_ERROR_001")));
+                .andExpect(jsonPath("message", containsString("SIGNUP_001")));
     }
 
     @DisplayName("비어있는 아이디 값으로 회원가입시 400코드가 반환된다")
@@ -86,7 +86,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("MEMBER_ERROR_010")));
+                .andExpect(jsonPath("message", containsString("MEMBER_010")));
     }
 
     @DisplayName("비어있는 비밀번호 값으로 회원가입시 400코드가 반환된다")
@@ -98,7 +98,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("MEMBER_ERROR_007")));
+                .andExpect(jsonPath("message", containsString("MEMBER_007")));
     }
 
     @DisplayName("잘못된 비밀번호 패턴으로 회원가입시 400코드가 반환된다")
@@ -110,7 +110,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("MEMBER_ERROR_008")));
+                .andExpect(jsonPath("message", containsString("MEMBER_008")));
     }
 
     @DisplayName("비어있는 이름 값으로 회원가입시 400코드가 반환된다")
@@ -122,7 +122,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("MEMBER_ERROR_005")));
+                .andExpect(jsonPath("message", containsString("MEMBER_005")));
     }
 
     @DisplayName("정상적으로 로그인될 시 토큰이 발급된다")
@@ -154,7 +154,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("MEMBER_ERROR_010")));
+                .andExpect(jsonPath("message", containsString("MEMBER_010")));
     }
 
     @DisplayName("비어있는 비밀번호 형식으로 로그인시 400코드가 반환된다")
@@ -167,7 +167,7 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .content(objectMapper.writeValueAsString(request))
                 ).andExpect(status().isBadRequest())
-                .andExpect(jsonPath("message", containsString("MEMBER_ERROR_007")));
+                .andExpect(jsonPath("message", containsString("MEMBER_007")));
     }
 
     @DisplayName("리프레시 토큰을 통해 엑세스 토큰을 재발급받는다")

--- a/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
@@ -14,12 +14,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.auth.domain.Token;
 import com.woowacourse.momo.auth.domain.TokenRepository;
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
 import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
+import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.MemberFindService;
 
 @Transactional
@@ -56,7 +58,7 @@ class AuthServiceTest {
 
         assertThatThrownBy(
                 () -> authService.signUp(request)
-        ).isInstanceOf(MomoException.class)
+        ).isInstanceOf(AuthException.class)
                 .hasMessageContaining("이미 가입된 아이디입니다.");
     }
 
@@ -113,7 +115,7 @@ class AuthServiceTest {
         LoginRequest request = new LoginRequest(USER_ID, "wrong123!");
 
         assertThatThrownBy(() -> authService.login(request))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("아이디나 비밀번호가 다릅니다.");
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
@@ -16,10 +16,10 @@ import com.woowacourse.momo.auth.domain.Token;
 import com.woowacourse.momo.auth.domain.TokenRepository;
 import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.MemberService;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
-import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.MemberFindService;
@@ -39,13 +39,16 @@ class AuthServiceTest {
     private AuthService authService;
 
     @Autowired
+    private MemberService memberService;
+
+    @Autowired
     private MemberFindService memberFindService;
 
     @DisplayName("회원 가입을 한다")
     @Test
     void signUp() {
         SignUpRequest request = new SignUpRequest(USER_ID, PASSWORD, NAME);
-        Long id = authService.signUp(request);
+        Long id = memberService.signUp(request);
 
         assertThat(id).isNotNull();
     }
@@ -54,10 +57,10 @@ class AuthServiceTest {
     @Test
     void signUpAlreadyExistId() {
         SignUpRequest request = new SignUpRequest(USER_ID, PASSWORD, NAME);
-        authService.signUp(request);
+        memberService.signUp(request);
 
         assertThatThrownBy(
-                () -> authService.signUp(request)
+                () -> memberService.signUp(request)
         ).isInstanceOf(AuthException.class)
                 .hasMessageContaining("이미 가입된 아이디입니다.");
     }
@@ -130,6 +133,6 @@ class AuthServiceTest {
 
     Long createMember(String userId, String password, String name) {
         SignUpRequest request = new SignUpRequest(userId, password, name);
-        return authService.signUp(request);
+        return memberService.signUp(request);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/auth/support/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/support/JwtTokenProviderTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
 class JwtTokenProviderTest {
@@ -19,7 +20,7 @@ class JwtTokenProviderTest {
         String accessToken = tokenProvider.createAccessToken(1L);
 
         assertThatThrownBy(() -> tokenProvider.validateTokenNotUsable(accessToken))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(AuthException.class)
                 .hasMessageContaining("토큰의 유효기간이 만료되었습니다.");
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/category/domain/CategoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.woowacourse.momo.category.exception.CategoryException;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 
 class CategoryTest {
@@ -13,7 +14,7 @@ class CategoryTest {
     @Test
     void from() {
         assertThatThrownBy(() -> Category.from(0))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(CategoryException.class)
                 .hasMessage("존재하지 않는 카테고리입니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupModifyControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupModifyControllerTest.java
@@ -38,7 +38,8 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.MemberService;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.category.domain.Category;
 import com.woowacourse.momo.fixture.calendar.ScheduleFixture;
 import com.woowacourse.momo.group.controller.dto.request.GroupApiRequest;
@@ -63,6 +64,7 @@ class GroupModifyControllerTest {
     private final ObjectMapper objectMapper;
     private final GroupModifyService groupModifyService;
     private final AuthService authService;
+    private final MemberService memberService;
 
     @DisplayName("그룹이 정상적으로 생성되는 경우를 테스트한다")
     @Test
@@ -185,6 +187,6 @@ class GroupModifyControllerTest {
 
     Long saveMember(String id, String password, String name) {
         SignUpRequest request = new SignUpRequest(id, password, name);
-        return authService.signUp(request);
+        return memberService.signUp(request);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupSearchControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupSearchControllerTest.java
@@ -30,7 +30,8 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.MemberService;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.category.domain.Category;
 import com.woowacourse.momo.fixture.calendar.ScheduleFixture;
 import com.woowacourse.momo.group.service.GroupModifyService;
@@ -51,6 +52,7 @@ class GroupSearchControllerTest {
     private final GroupModifyService groupModifyService;
     private final AuthService authService;
     private final LikeService likeService;
+    private final MemberService memberService;
 
     @DisplayName("로그인을 하지 않은 상태로 하나의 그룹을 가져오는 경우를 테스트한다")
     @Test
@@ -276,7 +278,7 @@ class GroupSearchControllerTest {
 
     Long saveMember(String id, String password, String name) {
         SignUpRequest request = new SignUpRequest(id, password, name);
-        return authService.signUp(request);
+        return memberService.signUp(request);
     }
 
     void likeGroup(Long groupId, Long memberId) {

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/LikeControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/LikeControllerTest.java
@@ -26,7 +26,8 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.MemberService;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.fixture.calendar.ScheduleFixture;
 import com.woowacourse.momo.group.service.GroupModifyService;
 import com.woowacourse.momo.group.service.LikeService;
@@ -47,6 +48,7 @@ class LikeControllerTest {
     private final AuthService authService;
     private final GroupModifyService groupModifyService;
     private final LikeService likeService;
+    private final MemberService memberService;
 
     @DisplayName("모임을 찜한다")
     @Test
@@ -93,7 +95,7 @@ class LikeControllerTest {
 
     Long saveMember(String userId) {
         SignUpRequest request = new SignUpRequest(userId, "wooteco1!", "momo");
-        return authService.signUp(request);
+        return memberService.signUp(request);
     }
 
     String accessToken(String userId) {

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.fixture.GroupFixture;
 import com.woowacourse.momo.fixture.calendar.ScheduleFixture;
 import com.woowacourse.momo.group.service.GroupFindService;
@@ -297,7 +297,7 @@ class ParticipateControllerTest {
 
     Long saveMember(String userId) {
         SignUpRequest request = new SignUpRequest(userId, "wooteco1!", "momo");
-        return authService.signUp(request);
+        return memberService.signUp(request);
     }
 
     String accessToken(String userId) {

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
@@ -87,7 +87,7 @@ class ParticipateControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message", is("GROUP_ERROR_001")))
+                .andExpect(jsonPath("$.message", is("GROUP_001")))
                 .andDo(
                         document("participatenotexistgroup",
                                 preprocessRequest(prettyPrint()),
@@ -110,7 +110,7 @@ class ParticipateControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("MEMBER_ERROR_002")))
+                .andExpect(jsonPath("$.message", is("MEMBER_002")))
                 .andDo(
                         document("participatenotexistmember",
                                 preprocessRequest(prettyPrint()),
@@ -133,7 +133,7 @@ class ParticipateControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("GROUP_ERROR_016")))
+                .andExpect(jsonPath("$.message", is("GROUP_016")))
                 .andDo(
                         document("participateparticipant",
                                 preprocessRequest(prettyPrint()),
@@ -155,7 +155,7 @@ class ParticipateControllerTest {
                         .header("Authorization", "bearer " + accessToken)
                 )
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message", is("GROUP_ERROR_013")))
+                .andExpect(jsonPath("$.message", is("GROUP_013")))
                 .andDo(
                         document("participatefullgroup",
                                 preprocessRequest(prettyPrint()),
@@ -189,7 +189,7 @@ class ParticipateControllerTest {
         mockMvc.perform(get(BASE_URL + 0 + RESOURCE)
                 )
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message", is("GROUP_ERROR_001")))
+                .andExpect(jsonPath("$.message", is("GROUP_001")))
                 .andDo(
                         document("findparticipantsnotexistgroup",
                                 preprocessRequest(prettyPrint()),

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/GroupTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/GroupTest.java
@@ -14,6 +14,7 @@ import static com.woowacourse.momo.fixture.MemberFixture.MOMO;
 import java.util.List;
 import java.util.stream.Stream;
 
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/backend/src/test/java/com/woowacourse/momo/group/service/ParticipateServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/ParticipateServiceTest.java
@@ -31,6 +31,7 @@ import com.woowacourse.momo.group.domain.GroupRepository;
 import com.woowacourse.momo.group.exception.GroupException;
 import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
+import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.MemberService;
 import com.woowacourse.momo.member.service.dto.response.MemberResponse;
 
@@ -89,7 +90,7 @@ class ParticipateServiceTest {
         long participantId = 0;
 
         assertThatThrownBy(() -> participateService.participate(groupId, participantId))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("멤버가 존재하지 않습니다.");
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/controller/MemberControllerTest.java
@@ -27,7 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.woowacourse.momo.auth.service.AuthService;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.MemberService;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
 
@@ -49,6 +50,9 @@ class MemberControllerTest {
 
     @Autowired
     AuthService authService;
+
+    @Autowired
+    MemberService memberService;
 
     String accessToken;
 
@@ -151,6 +155,6 @@ class MemberControllerTest {
     void signUp() {
         SignUpRequest signUpRequest = new SignUpRequest(ID, PASSWORD, NAME);
 
-        authService.signUp(signUpRequest);
+        memberService.signUp(signUpRequest);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/domain/PasswordTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/domain/PasswordTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.auth.support.SHA256Encoder;
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.member.exception.MemberException;
 
 class PasswordTest {
 
@@ -28,7 +29,7 @@ class PasswordTest {
     @ValueSource(strings = {"1234567!", "asdfghj!", "asdf1234", "12345678", "asdfghjk", "!@#$%^&*", "a1!", "123456789asdfgh!@#$"})
     void passwordMustBeValidPattern(String password) {
         assertThatThrownBy(() -> Password.encrypt(password, ENCODER))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("패스워드는 영문자와 하나 이상의 숫자, 특수 문자를 갖고 있어야 합니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/domain/UserIdTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/domain/UserIdTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.member.exception.MemberException;
 
 class UserIdTest {
 
@@ -16,7 +18,7 @@ class UserIdTest {
     @ValueSource(strings = {"", " "})
     void idMustNotBlank(String id) {
         assertThatThrownBy(() -> UserId.momo(id))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("사용자의 아이디가 빈 값입니다.");
     }
 
@@ -24,7 +26,7 @@ class UserIdTest {
     @Test
     void idMustNotBeInEmail() {
         assertThatThrownBy(() -> UserId.momo("id@woowacourse.com"))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("잘못된 형식의 아이디입니다.");
     }
 
@@ -32,7 +34,7 @@ class UserIdTest {
     @Test
     void googleIdMustBeInEmail() {
         assertThatThrownBy(() -> UserId.oauth("id"))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("구글 아이디가 이메일 형식이 아닙니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/domain/UserNameTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/domain/UserNameTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.woowacourse.momo.global.exception.exception.MomoException;
+import com.woowacourse.momo.member.exception.MemberException;
 
 class UserNameTest {
 
@@ -16,7 +17,7 @@ class UserNameTest {
     @ValueSource(strings = {"", " "})
     void nameMustNotBlank(String name) {
         assertThatThrownBy(() -> UserName.from(name))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("사용자의 이름이 빈 값입니다.");
     }
 
@@ -24,7 +25,7 @@ class UserNameTest {
     @Test
     void nameMustBe30OrLess() {
         assertThatThrownBy(() -> UserName.from("a".repeat(31)))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("사용자의 이름이 30자를 넘습니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberFindServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberFindServiceTest.java
@@ -16,6 +16,7 @@ import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.domain.Password;
 import com.woowacourse.momo.member.domain.UserId;
 import com.woowacourse.momo.member.domain.UserName;
+import com.woowacourse.momo.member.exception.MemberException;
 
 @Transactional
 @SpringBootTest
@@ -46,7 +47,7 @@ class MemberFindServiceTest {
     @Test
     void findNotExistMember() {
         assertThatThrownBy(() -> memberFindService.findMember(1000L))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("멤버가 존재하지 않습니다.");
     }
 
@@ -57,7 +58,7 @@ class MemberFindServiceTest {
         member.delete();
 
         assertThatThrownBy(() -> memberFindService.findMember(member.getId()))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("탈퇴한 멤버입니다.");
     }
 
@@ -79,7 +80,7 @@ class MemberFindServiceTest {
         Password wrongPassword = Password.encrypt("wrong123!", new SHA256Encoder());
         assertThatThrownBy(
                 () -> memberFindService.findByUserIdAndPassword(USER_ID, wrongPassword)
-        ).isInstanceOf(MomoException.class)
+        ).isInstanceOf(MemberException.class)
                 .hasMessageContaining("아이디나 비밀번호가 다릅니다.");
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.auth.domain.TokenRepository;
 import com.woowacourse.momo.auth.service.AuthService;
-import com.woowacourse.momo.auth.service.dto.request.SignUpRequest;
+import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.auth.support.SHA256Encoder;
 import com.woowacourse.momo.global.exception.exception.MomoException;
@@ -75,7 +75,7 @@ class MemberServiceTest {
     @Test
     void findById() {
         SignUpRequest request = new SignUpRequest("woowa", "wooteco1!", "모모");
-        Long memberId = authService.signUp(request);
+        Long memberId = memberService.signUp(request);
 
         MyInfoResponse response = memberService.findById(memberId);
 
@@ -122,7 +122,7 @@ class MemberServiceTest {
     void updatePassword() {
         String beforePassword = "wooteco1!";
         SignUpRequest signUpRequest = new SignUpRequest("woowa", beforePassword, "모모");
-        Long memberId = authService.signUp(signUpRequest);
+        Long memberId = memberService.signUp(signUpRequest);
 
         ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("newPassword123!", beforePassword);
         memberService.updatePassword(memberId, changePasswordRequest);
@@ -138,7 +138,7 @@ class MemberServiceTest {
     void updatePasswordWithWrongPassword() {
         String password = "wooteco1!";
         SignUpRequest signUpRequest = new SignUpRequest("woowa", password, "모모");
-        Long memberId = authService.signUp(signUpRequest);
+        Long memberId = memberService.signUp(signUpRequest);
 
         ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("newPassword123!", "wrongPassword");
         assertThatThrownBy(() -> memberService.updatePassword(memberId, changePasswordRequest))
@@ -195,7 +195,7 @@ class MemberServiceTest {
 
     private Long createMember() {
         SignUpRequest request = new SignUpRequest("woowa", "wooteco1!", "모모");
-        return authService.signUp(request);
+        return memberService.signUp(request);
     }
 
     private Group saveGroup() {

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberServiceTest.java
@@ -29,6 +29,7 @@ import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.domain.Password;
 import com.woowacourse.momo.member.domain.UserId;
 import com.woowacourse.momo.member.domain.UserName;
+import com.woowacourse.momo.member.exception.MemberException;
 import com.woowacourse.momo.member.service.dto.request.ChangeNameRequest;
 import com.woowacourse.momo.member.service.dto.request.ChangePasswordRequest;
 import com.woowacourse.momo.member.service.dto.response.MyInfoResponse;
@@ -89,7 +90,7 @@ class MemberServiceTest {
     @Test
     void findByIdNotExist() {
         assertThatThrownBy(() -> memberService.findById(1000L))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessageContaining("멤버가 존재하지 않습니다.");
     }
 
@@ -112,7 +113,7 @@ class MemberServiceTest {
     void updateNameNotExist() {
         ChangeNameRequest request = new ChangeNameRequest("무무");
 
-        assertThatThrownBy(() -> memberService.updateName(1000L, request)).isInstanceOf(MomoException.class)
+        assertThatThrownBy(() -> memberService.updateName(1000L, request)).isInstanceOf(MemberException.class)
                 .hasMessageContaining("멤버가 존재하지 않습니다.");
     }
 
@@ -141,7 +142,7 @@ class MemberServiceTest {
 
         ChangePasswordRequest changePasswordRequest = new ChangePasswordRequest("newPassword123!", "wrongPassword");
         assertThatThrownBy(() -> memberService.updatePassword(memberId, changePasswordRequest))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("비밀번호가 일치하지 않습니다.");
     }
 
@@ -155,7 +156,7 @@ class MemberServiceTest {
         assertAll(
                 () -> assertThat(tokenRepository.findByMemberId(memberId)).isEmpty(),
                 () -> assertThatThrownBy(() -> memberService.findById(memberId))
-                        .isInstanceOf(MomoException.class)
+                        .isInstanceOf(MemberException.class)
                         .hasMessage("탈퇴한 멤버입니다.")
         );
     }
@@ -164,7 +165,7 @@ class MemberServiceTest {
     @Test
     void deleteNotExistMember() {
         assertThatThrownBy(() -> memberService.findById(1000L))
-                .isInstanceOf(MomoException.class)
+                .isInstanceOf(MemberException.class)
                 .hasMessage("멤버가 존재하지 않습니다.");
     }
 


### PR DESCRIPTION
GlobalErrorCode를 각 도메인별 exception 패키지 내부로 이동시키고 관련 로직을 수정하였습니다.

추가로 회원가입 로직이 auth에 존재하였는데, 이를 member로 옮기게 되었으며,
이 과정에서 api가 피치못하게 api/auth/register에서 api/members로 바뀌도록 변경하였습니다.(POST)