### PR TITLE
[BE] 페이지네이션 과정에서 Page의 hasNext()가 잘못 나오는 오류 + 찜 조회 기능 오류

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -79,9 +79,8 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
 
     public List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
         return queryFactory
-                .select(group.id)
+                .select(group.id).distinct()
                 .from(group)
-                .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)
                 .where(
                         favorite.member.eq(member),

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -54,7 +54,8 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
     @Override
     public Page<Group> findLikedGroups(SearchCondition condition, Member member, Pageable pageable) {
         List<Group> groups = queryFactory
-                .selectFrom(group)
+                .select(group).distinct()
+                .from(group)
                 .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)
                 .fetchJoin()
@@ -63,7 +64,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
-                .select(group.count())
+                .select(group.countDistinct())
                 .from(group)
                 .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -79,7 +79,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
 
     public List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
         return queryFactory
-                .select(group.id).distinct()
+                .select(group.id)
                 .from(group)
                 .innerJoin(group.favorites.favorites, favorite)
                 .where(

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -54,8 +54,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
     @Override
     public Page<Group> findLikedGroups(SearchCondition condition, Member member, Pageable pageable) {
         List<Group> groups = queryFactory
-                .select(group).distinct()
-                .from(group)
+                .selectFrom(group)
                 .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)
                 .fetchJoin()
@@ -64,7 +63,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                 .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
-                .select(group.countDistinct())
+                .select(group.count())
                 .from(group)
                 .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)
@@ -77,7 +76,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
 
     private List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
         return queryFactory
-                .select(group.id)
+                .select(group.id).distinct()
                 .from(group)
                 .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -58,13 +58,20 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
                 .leftJoin(group.participants.participants, participant)
                 .innerJoin(group.favorites.favorites, favorite)
                 .fetchJoin()
-                .where(
-                        group.id.in(findLikedGroupIds(condition, member, pageable))
-                )
+                .where(group.id.in(findLikedGroupIds(condition, member, pageable)))
                 .orderBy(orderByDeadlineAsc(condition.orderByDeadline()).toArray(OrderSpecifier[]::new))
                 .fetch();
 
-        return PageableExecutionUtils.getPage(groups, pageable, groups::size);
+        JPAQuery<Long> countQuery = queryFactory
+                .select(group.count())
+                .from(group)
+                .leftJoin(group.participants.participants, participant)
+                .innerJoin(group.favorites.favorites, favorite)
+                .where(
+                        group.id.in(findLikedGroupIds(condition, member, pageable))
+                );
+
+        return PageableExecutionUtils.getPage(groups, pageable, countQuery::fetchOne);
     }
 
     private List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {

--- a/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/infrastructure/querydsl/GroupSearchRepositoryImpl.java
@@ -77,7 +77,7 @@ public class GroupSearchRepositoryImpl implements GroupSearchRepositoryCustom {
         return PageableExecutionUtils.getPage(groups, pageable, countQuery::fetchOne);
     }
 
-    public List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
+    private List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
         return queryFactory
                 .select(group.id)
                 .from(group)

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/GroupSearchControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/GroupSearchControllerTest.java
@@ -181,7 +181,7 @@ class GroupSearchControllerTest {
         likeGroup(groupId4, saveMemberId);
 
         mockMvc.perform(MockMvcRequestBuilders.get(
-                                "/api/groups/me/liked?keyword=모모&excludeFinished=true&orderByDeadline=true&page=0")
+                                "/api/groups/me/liked?keyword=모모&excludeFinished=true&orderByDeadline=false&page=0")
                         .header("Authorization", "bearer " + token))
                 .andExpect(status().is(HttpStatus.OK.value()))
                 .andExpect(jsonPath("groups[0].name", is("모모의 리엑트 스터디")))

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
@@ -150,7 +150,7 @@ class GroupSearchServiceTest {
             );
         }
 
-        @DisplayName("모임 목록중 두번째 페이지를 조회한다")
+        @DisplayName("모임 목록중 첫번째 페이지를 조회한다")
         @Test
         void findLikedGroupsFirstPage() {
             GroupSearchRequest request = new GroupSearchRequest();
@@ -161,6 +161,20 @@ class GroupSearchServiceTest {
             assertAll(
                     () -> assertThat(actual.isHasNextPage()).isTrue(),
                     () -> assertThat(actual.getGroups()).hasSize(PAGE_SIZE)
+            );
+        }
+
+        @DisplayName("모임 목록중 두번째 페이지를 조회한다")
+        @Test
+        void findLikedGroupsSecondPage() {
+            GroupSearchRequest request = new GroupSearchRequest();
+            request.setPage(1);
+
+            GroupPageResponse actual = groupService.findLikedGroups(request, host.getId());
+
+            assertAll(
+                    () -> assertThat(actual.isHasNextPage()).isFalse(),
+                    () -> assertThat(actual.getGroups()).hasSize(TWO_PAGE_GROUPS)
             );
         }
     }


### PR DESCRIPTION
## ✨ Issue
- #391 

## 🐞 버그 내용
### 🐛 페이지네이션 과정에서 Page의 hasNext()가 잘못 나오는 오류
페이지네이션을 하는 과정에서 전체 데이터를 조회하는 쿼리를 분리하지 않았다.
그 결과 `전체 데이터==조회한 데이터의 수(최대 12개)`의 상황이 나와서 항상 hasNextPage가 false였다.
```java
        JPAQuery<Long> countQuery = queryFactory
                .select(group.count())
                .from(group)
                .leftJoin(group.participants.participants, participant)
                .innerJoin(group.favorites.favorites, favorite)
                .where(
                        group.id.in(likedGroupIds)
                );
```
모임들을 조회하는 메서드들에 해당 쿼리를 추가하며 문제를 해결하였다.

### 🐛 중복된 찜 목록조회 오류 수정
찜한 모임 목록을 조회할 때, 엔티티 조회 과정에서 distinct를 붙이지 않아 participant의 수만큼 모임이 조회되는 오류가 발생하여 해결하였다.

### 🐛 찜 목록 조회시 참여자의 수만큼 id가 조회되어 적은 데이터가 조회되는 오류
찜 목록 조회를 할 때, 찜한 모임의 ID를 모두 조회한 후 해당 ID를 통해 모임 엔티티를 조회하였다. 
하지만 이때 찜한 모임의 id를 조회하는 과정에서 아래와 같이 불필요하게 participant를 leftjoin하였다. 그 결과 데이터의 뻥튀기가 발생하며 반환되는 엔티티의 수가 예상과는 다르게 반환되었다.
```java
    public List<Long> findLikedGroupIds(SearchCondition condition, Member member, Pageable pageable) {
        return queryFactory
                .select(group.id)
                .from(group)
                .leftJoin(group.participants.participants, participant)
                .innerJoin(group.favorites.favorites, favorite)
                .where(
                        favorite.member.eq(member),
                        conditionFilter.filterByCondition(condition)
                )
                .orderBy(orderByDeadlineAsc(condition.orderByDeadline()).toArray(OrderSpecifier[]::new))
                .offset(pageable.getOffset())
                .limit(pageable.getPageSize())
                .fetch();
    }
```
해당 오류는 participant의 조인을 없애며 문제를 해결하였다.
> 📌 이프, 라쿤의 도움덕분에 해결하였다..👍