### PR TITLE
[BE] 조기마감된 모임에 대한 에러코드가 마감기한이 지나도 동일한 이슈

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/Group.java
@@ -2,7 +2,6 @@ package com.woowacourse.momo.group.domain;
 
 import static com.woowacourse.momo.group.exception.GroupErrorCode.ALREADY_CLOSED_EARLY;
 import static com.woowacourse.momo.group.exception.GroupErrorCode.ALREADY_DEADLINE_OVER;
-import static com.woowacourse.momo.group.exception.GroupErrorCode.PARTICIPANT_EXIST;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -116,8 +115,8 @@ public class Group {
     }
 
     public void validateGroupIsProceeding() {
-        validateGroupIsNotClosedEarly();
         validateDeadlineNotOver();
+        validateGroupIsNotClosedEarly();
     }
 
     private void validateGroupIsNotClosedEarly() {


### PR DESCRIPTION
## 변경 기능
- 모임진행 유효성 검증 절차 순서를 변경함
  - 기존: 조기마감여부 확인 후 마감기한 확인
  - 변경: 마감기한 확인 후 조기마감여부 확인 

## 관련 이슈
- #402 