### PR TITLE
[FE] 메인 페이지에서 검색 시 새롭게 들어온 모임 목록이 기존 모임 목록에 추가되는 오류 해결

### DIFF
--- a/frontend/src/pages/Main/index.tsx
+++ b/frontend/src/pages/Main/index.tsx
@@ -49,6 +49,11 @@ function Main() {
       setPageNumber(data.pageNumber + 1);
     }
 
+    if (data.pageNumber === 0) {
+      setGroups(data.groups);
+      return;
+    }
+
     setGroups(prevState => [...prevState, ...data.groups]);
   }, [data]);
 


### PR DESCRIPTION
## Issue

- #406 

## Description (optional)

- 검색 시 기존에 존재하던 모임에 덮어씌우도록 추가

closed #406 