### PR TITLE
[BE] 모임의 일정이 설정한 날짜보다 하루 전날로 저장되는 현상 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/MomoApplication.java
+++ b/backend/src/main/java/com/woowacourse/momo/MomoApplication.java
@@ -1,10 +1,19 @@
 package com.woowacourse.momo;
 
+import java.util.TimeZone;
+
+import javax.annotation.PostConstruct;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class MomoApplication {
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(MomoApplication.class, args);

--- a/backend/src/main/java/com/woowacourse/momo/MomoApplication.java
+++ b/backend/src/main/java/com/woowacourse/momo/MomoApplication.java
@@ -1,19 +1,10 @@
 package com.woowacourse.momo;
 
-import java.util.TimeZone;
-
-import javax.annotation.PostConstruct;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class MomoApplication {
-
-    @PostConstruct
-    public void started() {
-        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-    }
 
     public static void main(String[] args) {
         SpringApplication.run(MomoApplication.class, args);

--- a/backend/src/main/java/com/woowacourse/momo/global/config/TimeConfig.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/TimeConfig.java
@@ -1,0 +1,16 @@
+package com.woowacourse.momo.global.config;
+
+import java.util.TimeZone;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}


### PR DESCRIPTION
## ✨ Issue
- #408 

## 🐞 문제 상황
모임에서 설정한 일정과 모집 기간의 날짜가 하루 전날로 저장 및 조회되었다.

## ❗️ 해결 방법
프로젝트의 전체 TimeZone 을 UTC+09:00으로 설정해 주었다.