### PR TITLE
[BE] 지원하지 않은 API 요청에 대해 404 반환

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/config/AuthConfiguration.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,12 @@ public class AuthConfiguration implements WebMvcConfigurer {
 
         registry.addInterceptor(new RefreshTokenAuthInterceptor(jwtTokenProvider, tokenRepository))
                 .addPathPatterns("/api/auth/reissueAccessToken");
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/docs/index.html")
+                .addResourceLocations("classpath:/static/");
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
@@ -17,25 +17,32 @@ public class ControllerAdvice {
 
     @ExceptionHandler(MomoException.class)
     public ResponseEntity<ExceptionResponse> handleException(MomoException e) {
-        return ResponseEntity.status(e.getStatusCode()).body(ExceptionResponse.from(e.getErrorCode()));
+        int statusCode = e.getStatusCode();
+        ExceptionResponse response = ExceptionResponse.from(e.getErrorCode());
+
+        return ResponseEntity.status(statusCode).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        return ResponseEntity.badRequest()
-                .body(ExceptionResponse.from(GlobalErrorCode.VALIDATION_ERROR.getErrorCode()));
+        return convert(GlobalErrorCode.VALIDATION_ERROR);
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ExceptionResponse> unhandledApiException(NoHandlerFoundException exception) {
-        ErrorCode e = GlobalErrorCode.UNHANDLED_API_ERROR;
-        return ResponseEntity.status(e.getStatusCode()).body(ExceptionResponse.from(e.getErrorCode()));
+    public ResponseEntity<ExceptionResponse> unhandledApiException(NoHandlerFoundException e) {
+        return convert(GlobalErrorCode.UNHANDLED_API_ERROR);
     }
 
     @UnhandledErrorLogging
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleAnyException(Exception e) {
-        return ResponseEntity.internalServerError()
-                .body(ExceptionResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR.getErrorCode()));
+        return convert(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ExceptionResponse> convert(ErrorCode errorCode) {
+        int statusCode = errorCode.getStatusCode();
+        ExceptionResponse response = ExceptionResponse.from(errorCode.getErrorCode());
+
+        return ResponseEntity.status(statusCode).body(response);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
@@ -4,8 +4,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.woowacourse.momo.global.exception.dto.response.ExceptionResponse;
+import com.woowacourse.momo.global.exception.exception.ErrorCode;
 import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.global.logging.UnhandledErrorLogging;
@@ -20,12 +22,20 @@ public class ControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        return ResponseEntity.badRequest().body(ExceptionResponse.from(GlobalErrorCode.VALIDATION_ERROR.getErrorCode()));
+        return ResponseEntity.badRequest()
+                .body(ExceptionResponse.from(GlobalErrorCode.VALIDATION_ERROR.getErrorCode()));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ExceptionResponse> unhandledApiException(NoHandlerFoundException exception) {
+        ErrorCode e = GlobalErrorCode.UNHANDLED_API_ERROR;
+        return ResponseEntity.status(e.getStatusCode()).body(ExceptionResponse.from(e.getErrorCode()));
     }
 
     @UnhandledErrorLogging
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleAnyException(Exception e) {
-        return ResponseEntity.internalServerError().body(ExceptionResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR.getErrorCode()));
+        return ResponseEntity.internalServerError()
+                .body(ExceptionResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR.getErrorCode()));
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum GlobalErrorCode implements ErrorCode {
 
+    UNHANDLED_API_ERROR(404, "NOT_FOUND", "지원하지 않는 API 요청입니다."),
     VALIDATION_ERROR(400, "VALIDATION_001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(500, "SERVER_001", "내부 서버 오류입니다."),
     ;

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -7,3 +7,6 @@ spring:
       - security/application-dev-datasource.yml
       - application-datasource.yml
       - application-logging.yml
+
+  mvc.throw-exception-if-no-handler-found: true
+  web.resources.add-mappings: false

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -7,3 +7,6 @@ spring:
       - security/application-local-datasource.yml
       - application-datasource.yml
       - application-logging.yml
+
+  mvc.throw-exception-if-no-handler-found: true
+  web.resources.add-mappings: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -7,3 +7,6 @@ spring:
       - security/application-prod-datasource.yml
       - application-datasource.yml
       - application-logging.yml
+
+  mvc.throw-exception-if-no-handler-found: true
+  web.resources.add-mappings: false

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -5,3 +5,6 @@ spring:
       - security/application-datasource.yml
       - application-datasource.yml
       - application-logging.yml
+
+  mvc.throw-exception-if-no-handler-found: true
+  web.resources.add-mappings: false


### PR DESCRIPTION
## Issue
- https://github.com/woowacourse-teams/2022-momo/issues/412

## 변경 및 적용 사항
- 기능추가 : 지원하지 않는 API 요청에 대한 예외처리
  - 에러 코드 등록
    - `UNHANDLED_API_ERROR(404, "NOT_FOUND", "지원하지 않는 API 요청입니다.")`
  - application.yml 설정값 등록
    - mvc.throw-exception-if-no-handler-found: true
      - DispatcherServlet에서 해당 상황을 Exception Throw할 것인지 지정
    - web.resources.add-mappings: false
      - no handler 상황에서 ResourceHttpRequestHandler를 반환하지 않도록 지정
      - 해당 설정을 해야 AuthInterceptor의 `(HandlerMethod) handler` 에서 발생하던
      - ClassCastException을 해결할 수 있었고 ControllerAdvise에서 NoHandlerFoundException 예외를 탐지할 수 있었음.
      - 참고: [SpringBoot 존재하지 않는 API 요청의 응답 커스마이징하기](https://tecoble.techcourse.co.kr/post/2021-11-24-spring-customize-unhandled-api/)
- 리팩토링 : ControllerAdvise 중복 로직 메서드 추출


## 비고
- application.yml 중복 제거 및 구조 변경은 별도의 이슈로 진행하겠습니다~