### PR TITLE
[BE] 모임 참여 요청이 동시에 왔을 때 참여 인원을 초과하는 문제

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
@@ -31,8 +31,8 @@ public class Capacity {
         this.value = value;
     }
 
-    public boolean isSame(int numberOfPeople) {
-        return value == numberOfPeople;
+    public boolean isEqualOrOver(int numberOfPeople) {
+        return value <= numberOfPeople;
     }
 
     public boolean isSmallThan(int numberOfPeople) {

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Capacity.java
@@ -46,6 +46,6 @@ public class Capacity {
     }
 
     private static boolean isOutOfRange(int capacity) {
-        return (MINIMUM > capacity) || (capacity > MAXIMUM);
+        return MINIMUM > capacity || capacity > MAXIMUM;
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
@@ -120,7 +120,7 @@ public class Participants {
     }
 
     public boolean isFull() {
-        return capacity.isSame(getSize());
+        return capacity.isEqualOrOver(getSize());
     }
 
     public boolean isHost(Member member) {

--- a/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
@@ -22,7 +22,7 @@ public class ParticipateService {
     private final GroupFindService groupFindService;
 
     @Transactional
-    public void participate(Long groupId, Long memberId) {
+    public synchronized void participate(Long groupId, Long memberId) {
         Group group = groupFindService.findGroup(groupId);
         Member member = memberFindService.findMember(memberId);
 

--- a/backend/src/test/java/com/woowacourse/momo/group/domain/participant/CapacityTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/domain/participant/CapacityTest.java
@@ -34,17 +34,18 @@ class CapacityTest {
                 .hasMessage("모임 내 인원은 1명 이상 99명 이하여야 합니다.");
     }
 
-    @DisplayName("주어진 값과 동일한지 확인한다")
+    @DisplayName("주어진 값 이상인지 확인한다")
     @ParameterizedTest
     @MethodSource("provideIsFullArguments")
     void isSame(int num, boolean expected) {
         Capacity capacity = new Capacity(1);
 
-        assertThat(capacity.isSame(num)).isEqualTo(expected);
+        assertThat(capacity.isEqualOrOver(num)).isEqualTo(expected);
     }
 
     private static Stream<Arguments> provideIsFullArguments() {
         return Stream.of(
+                Arguments.of(2, Boolean.TRUE),
                 Arguments.of(1, Boolean.TRUE),
                 Arguments.of(0, Boolean.FALSE)
         );


### PR DESCRIPTION
## ✨ Issue
- #430

##  작업한 기능
- [x] 참여하기 로직에 `synchronized`추가
- [x] 모임 인원이 가득차는 것을 검증하는 로직을 `==` 에서 `<= `로 수정