### PR TITLE
[BE] 동일한 사용자 이름으로 회원가입하는 경우에 대한 유효성 검증

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
@@ -13,11 +13,6 @@ public enum AuthErrorCode implements ErrorCode {
     OAUTH_ACCESS_TOKEN_REQUEST_FAILED_BY_NON_EXIST_BODY(500, "OAUTH_001", "구글에 요청한 Access 토큰에 대하여 응답 Body가 비어 있습니다."),
     OAUTH_USERINFO_REQUEST_FAILED_BY_NON_2XX_STATUS(500, "OAUTH_001", "구글에 전송한 회원정보 요청이 실패했습니다."),
     OAUTH_USERINFO_REQUEST_FAILED_BY_NON_EXIST_BODY(500, "OAUTH_001", "구글에 요청한 회원정보에 대하여 응답 Body가 비어 있습니다."),
-
-    SIGNUP_INVALID_ID(400, "SIGNUP_001", "잘못된 형식의 아이디입니다."),
-    SIGNUP_INVALID_PASSWORD(400, "SIGNUP_002", "잘못된 형식의 비밀번호입니다."),
-    SIGNUP_USER_ID_DUPLICATED(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
-    SIGNUP_USER_NAME_DUPLICATED(400, "SIGNUP_003", "이미 가입된 이름입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/auth/exception/AuthErrorCode.java
@@ -16,7 +16,8 @@ public enum AuthErrorCode implements ErrorCode {
 
     SIGNUP_INVALID_ID(400, "SIGNUP_001", "잘못된 형식의 아이디입니다."),
     SIGNUP_INVALID_PASSWORD(400, "SIGNUP_002", "잘못된 형식의 비밀번호입니다."),
-    SIGNUP_ALREADY_REGISTER(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
+    SIGNUP_USER_ID_DUPLICATED(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
+    SIGNUP_USER_NAME_DUPLICATED(400, "SIGNUP_003", "이미 가입된 이름입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/domain/MemberRepository.java
@@ -9,4 +9,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUserIdAndPassword(UserId userId, Password password);
 
     Optional<Member> findByUserId(UserId userId);
+
+    boolean existsByUserId(UserId userId);
+
+    boolean existsByUserName(UserName userName);
 }

--- a/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/exception/MemberErrorCode.java
@@ -21,7 +21,8 @@ public enum MemberErrorCode implements ErrorCode {
 
     SIGNUP_INVALID_ID(400, "SIGNUP_001", "잘못된 형식의 아이디입니다."),
     SIGNUP_INVALID_PASSWORD(400, "SIGNUP_002", "잘못된 형식의 비밀번호입니다."),
-    SIGNUP_ALREADY_REGISTER(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
+    SIGNUP_USER_ID_DUPLICATED(400, "SIGNUP_003", "이미 가입된 아이디입니다."),
+    SIGNUP_USER_NAME_DUPLICATED(400, "SIGNUP_004", "이미 가입된 이름입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -10,8 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.domain.TokenRepository;
-import com.woowacourse.momo.auth.exception.AuthErrorCode;
-import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.support.PasswordEncoder;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.Group;
@@ -47,7 +45,7 @@ public class MemberService {
         UserId userId = UserId.momo(request.getUserId());
         UserName userName = UserName.from(request.getName());
         Password password = Password.encrypt(request.getPassword(), passwordEncoder);
-        validateUserIsNotDuplicated(userId);
+        validateUserIdIsNotDuplicated(userId);
         validateUserNameNotDuplicated(userName);
 
         Member member = new Member(userId, password, userName);
@@ -56,15 +54,15 @@ public class MemberService {
         return savedMember.getId();
     }
 
-    private void validateUserIsNotDuplicated(UserId userId) {
+    private void validateUserIdIsNotDuplicated(UserId userId) {
         if (memberRepository.existsByUserId(userId)) {
-            throw new AuthException(AuthErrorCode.SIGNUP_USER_ID_DUPLICATED);
+            throw new MemberException(MemberErrorCode.SIGNUP_USER_ID_DUPLICATED);
         }
     }
 
     private void validateUserNameNotDuplicated(UserName userName) {
         if (memberRepository.existsByUserName(userName)) {
-            throw new AuthException(AuthErrorCode.SIGNUP_USER_NAME_DUPLICATED);
+            throw new MemberException(MemberErrorCode.SIGNUP_USER_NAME_DUPLICATED);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -46,7 +46,7 @@ public class MemberService {
         UserName userName = UserName.from(request.getName());
         Password password = Password.encrypt(request.getPassword(), passwordEncoder);
         validateUserIdIsNotDuplicated(userId);
-        validateUserNameNotDuplicated(userName);
+        validateUserNameIsNotDuplicated(userName);
 
         Member member = new Member(userId, password, userName);
         Member savedMember = memberRepository.save(member);
@@ -60,7 +60,7 @@ public class MemberService {
         }
     }
 
-    private void validateUserNameNotDuplicated(UserName userName) {
+    private void validateUserNameIsNotDuplicated(UserName userName) {
         if (memberRepository.existsByUserName(userName)) {
             throw new MemberException(MemberErrorCode.SIGNUP_USER_NAME_DUPLICATED);
         }

--- a/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/momo/member/service/MemberService.java
@@ -1,7 +1,6 @@
 package com.woowacourse.momo.member.service;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -48,18 +47,24 @@ public class MemberService {
         UserId userId = UserId.momo(request.getUserId());
         UserName userName = UserName.from(request.getName());
         Password password = Password.encrypt(request.getPassword(), passwordEncoder);
-        Member member = new Member(userId, password, userName);
+        validateUserIsNotDuplicated(userId);
+        validateUserNameNotDuplicated(userName);
 
-        validateUserIsNotExist(userId);
+        Member member = new Member(userId, password, userName);
         Member savedMember = memberRepository.save(member);
 
         return savedMember.getId();
     }
 
-    private void validateUserIsNotExist(UserId userId) {
-        Optional<Member> member = memberRepository.findByUserId(userId);
-        if (member.isPresent()) {
-            throw new AuthException(AuthErrorCode.SIGNUP_ALREADY_REGISTER);
+    private void validateUserIsNotDuplicated(UserId userId) {
+        if (memberRepository.existsByUserId(userId)) {
+            throw new AuthException(AuthErrorCode.SIGNUP_USER_ID_DUPLICATED);
+        }
+    }
+
+    private void validateUserNameNotDuplicated(UserName userName) {
+        if (memberRepository.existsByUserName(userName)) {
+            throw new AuthException(AuthErrorCode.SIGNUP_USER_NAME_DUPLICATED);
         }
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/auth/service/AuthServiceTest.java
@@ -8,13 +8,14 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.auth.domain.Token;
 import com.woowacourse.momo.auth.domain.TokenRepository;
-import com.woowacourse.momo.auth.exception.AuthException;
 import com.woowacourse.momo.auth.service.dto.request.LoginRequest;
 import com.woowacourse.momo.auth.service.dto.response.AccessTokenResponse;
 import com.woowacourse.momo.auth.service.dto.response.LoginResponse;
@@ -25,6 +26,8 @@ import com.woowacourse.momo.member.service.MemberService;
 import com.woowacourse.momo.member.service.dto.request.SignUpRequest;
 
 @Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
 @SpringBootTest
 class AuthServiceTest {
 
@@ -32,38 +35,10 @@ class AuthServiceTest {
     private static final String PASSWORD = "wooteco1!";
     private static final String NAME = "모모";
 
-    @Autowired
-    private TokenRepository tokenRepository;
-
-    @Autowired
-    private AuthService authService;
-
-    @Autowired
-    private MemberService memberService;
-
-    @Autowired
-    private MemberFindService memberFindService;
-
-    @DisplayName("회원 가입을 한다")
-    @Test
-    void signUp() {
-        SignUpRequest request = new SignUpRequest(USER_ID, PASSWORD, NAME);
-        Long id = memberService.signUp(request);
-
-        assertThat(id).isNotNull();
-    }
-
-    @DisplayName("이미 존재하는 아이디로 회원 가입을 하는 경우 실패한다")
-    @Test
-    void signUpAlreadyExistId() {
-        SignUpRequest request = new SignUpRequest(USER_ID, PASSWORD, NAME);
-        memberService.signUp(request);
-
-        assertThatThrownBy(
-                () -> memberService.signUp(request)
-        ).isInstanceOf(AuthException.class)
-                .hasMessageContaining("이미 가입된 아이디입니다.");
-    }
+    private final TokenRepository tokenRepository;
+    private final AuthService authService;
+    private final MemberService memberService;
+    private final MemberFindService memberFindService;
 
     @DisplayName("로그인을 성공한다")
     @Test

--- a/backend/src/test/java/com/woowacourse/momo/favorite/controller/FavoriteControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/favorite/controller/FavoriteControllerTest.java
@@ -94,7 +94,7 @@ class FavoriteControllerTest {
     }
 
     Long saveMember(String userId) {
-        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", "momo");
+        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", userId);
         return memberService.signUp(request);
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/favorite/controller/FavoriteControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/favorite/controller/FavoriteControllerTest.java
@@ -53,9 +53,9 @@ class FavoriteControllerTest {
     @DisplayName("모임을 찜한다")
     @Test
     void like() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long memberId = saveMember("member");
+        Long memberId = saveMember("member", "member");
         String accessToken = accessToken("member");
 
         mockMvc.perform(post(BASE_URL + groupId + RESOURCE)
@@ -74,9 +74,9 @@ class FavoriteControllerTest {
     @DisplayName("모임을 찜하기를 취소한다")
     @Test
     void cancelLike() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long memberId = saveMember("member");
+        Long memberId = saveMember("member", "member");
         likeMember(groupId, memberId);
         String accessToken = accessToken("member");
 
@@ -93,8 +93,8 @@ class FavoriteControllerTest {
                 );
     }
 
-    Long saveMember(String userId) {
-        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", userId);
+    Long saveMember(String userId, String userName) {
+        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", userName);
         return memberService.signUp(request);
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
@@ -59,9 +59,9 @@ class ParticipateControllerTest {
     @DisplayName("모임에 참여한다")
     @Test
     void participate() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         String accessToken = accessToken("participant");
 
         mockMvc.perform(post(BASE_URL + groupId + RESOURCE)
@@ -80,7 +80,7 @@ class ParticipateControllerTest {
     @DisplayName("존재하지 않는 모임에 참여할 수 없다")
     @Test
     void participateNotExistGroup() throws Exception {
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         String accessToken = accessToken("participant");
 
         mockMvc.perform(post(BASE_URL + 0 + RESOURCE)
@@ -100,9 +100,9 @@ class ParticipateControllerTest {
     @DisplayName("탈퇴한 사용자는 모임에 참여할 수 없다")
     @Test
     void participateDeletedMember() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         String accessToken = accessToken("participant");
         deleteMember(participantId);
 
@@ -123,9 +123,9 @@ class ParticipateControllerTest {
     @DisplayName("모임에 이미 속해있을 경우 모임에 참여할 수 없다")
     @Test
     void reParticipate() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         String accessToken = accessToken("participant");
         participateMember(groupId, participantId);
 
@@ -146,9 +146,9 @@ class ParticipateControllerTest {
     @DisplayName("모임 정원이 가득 찬 경우 참여를 할 수 없다")
     @Test
     void participateFullGroup() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroupWithSetCapacity(hostId, 1);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         String accessToken = accessToken("participant");
 
         mockMvc.perform(post(BASE_URL + groupId + RESOURCE)
@@ -168,7 +168,7 @@ class ParticipateControllerTest {
     @DisplayName("모임의 참여자 목록을 조회한다")
     @Test
     void findParticipants() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
 
         mockMvc.perform(get(BASE_URL + groupId + RESOURCE)
@@ -202,9 +202,9 @@ class ParticipateControllerTest {
     @DisplayName("모임에 탈퇴한다")
     @Test
     void deleteParticipant() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         participateMember(groupId, participantId);
         String accessToken = accessToken("participant");
 
@@ -221,7 +221,7 @@ class ParticipateControllerTest {
     @DisplayName("주최자일 경우 모임에 탈퇴할 수 없다")
     @Test
     void deleteHost() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
         String accessToken = accessToken("host");
 
@@ -238,9 +238,9 @@ class ParticipateControllerTest {
     @DisplayName("모임에 참여하지 않았으면 탈퇴할 수 없다")
     @Test
     void deleteNotParticipant() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long memberId = saveMember("member");
+        Long memberId = saveMember("member", "member");
         String accessToken = accessToken("member");
 
         mockMvc.perform(delete(BASE_URL + groupId + RESOURCE)
@@ -256,9 +256,9 @@ class ParticipateControllerTest {
     @DisplayName("모집 마감이 끝난 모임에는 탈퇴할 수 없다")
     @Test
     void deleteDeadline() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         participateMember(groupId, participantId);
         String accessToken = accessToken("participant");
 
@@ -277,9 +277,9 @@ class ParticipateControllerTest {
     @DisplayName("조기 종료된 모임에는 탈퇴할 수 없다")
     @Test
     void deleteEarlyClosed() throws Exception {
-        Long hostId = saveMember("host");
+        Long hostId = saveMember("host", "host");
         Long groupId = saveGroup(hostId);
-        Long participantId = saveMember("participant");
+        Long participantId = saveMember("participant", "participant");
         participateMember(groupId, participantId);
         String accessToken = accessToken("participant");
 
@@ -295,8 +295,8 @@ class ParticipateControllerTest {
                 );
     }
 
-    Long saveMember(String userId) {
-        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", userId);
+    Long saveMember(String userId, String userName) {
+        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", userName);
         return memberService.signUp(request);
     }
 

--- a/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/controller/ParticipateControllerTest.java
@@ -296,7 +296,7 @@ class ParticipateControllerTest {
     }
 
     Long saveMember(String userId) {
-        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", "momo");
+        SignUpRequest request = new SignUpRequest(userId, "wooteco1!", userId);
         return memberService.signUp(request);
     }
 


### PR DESCRIPTION
🚀 기능 추가 설명
- https://github.com/woowacourse-teams/2022-momo/issues/414
- 위의 PR에서 반영했던 `사용자 아이디 Unique 적용`에 대해 유효성 검증 로직을 추가
