### PR TITLE
[BE] 모임 장소 수정 시 세부내용이 잘못 업데이트 되는 이슈 발생

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/controller/dto/request/GroupRequestAssembler.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/controller/dto/request/GroupRequestAssembler.java
@@ -33,7 +33,7 @@ public class GroupRequestAssembler {
     }
 
     public LocationRequest groupLocationUpdateRequest(LocationUpdateApiRequest request) {
-        return new LocationRequest(request.getAddress(), request.getBuildingName(), request.getBuildingName());
+        return new LocationRequest(request.getAddress(), request.getBuildingName(), request.getDetail());
     }
 
     private DurationRequest durationRequest(DurationApiRequest request) {


### PR DESCRIPTION
모임 수정 API 요청 정보로부터 데이터를 잘못 사용하고 있음을 코드 상 파악했고,
3번째 인자에 잘못 지정된 getBuildingName()을 getDetail()로 변경했다
<img width="888" alt="스크린샷 2022-10-12 오후 2 47 15" src="https://user-images.githubusercontent.com/22176552/195261142-8a6fe7c1-c738-4d6a-a5da-91445105c3e9.png">
