### PR TITLE
[BE] 모임 참여 취소시 DB에 데이터가 삭제되지 않는 오류

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/Participants.java
@@ -37,7 +37,7 @@ public class Participants {
     @JoinColumn(name = "host_id")
     private Member host;
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "group", orphanRemoval = true, cascade = CascadeType.PERSIST)
     private final List<Participant> participants = new ArrayList<>();
 
     @Embedded


### PR DESCRIPTION
## ✨Issue
- #458 

## 🚀 진행 내용
쿼리 성능 개선을 하며 참여 취소를 하였을 때, 데이터를 삭제하는 로직 추가하는 것이 누락되었다. 
회의 결과 참여자 데이터 단건 취소에 대해서는 Orphanremoval을 통해 삭제하고, 모임 삭제시 참여자, 스케줄 전체 삭제에 대한 것은 직접 정의한 JPQL 쿼리를 사용하기로 정하여 Participant에 대해 Orphanremoval옵션을 추가했다.