### PR TITLE
[BE] 모임 목록 조회 시 이미지 정보가 없으면 빈값으로 보여지는 현상

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/search/dto/GroupSummaryRepositoryResponse.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/search/dto/GroupSummaryRepositoryResponse.java
@@ -2,13 +2,11 @@ package com.woowacourse.momo.group.domain.search.dto;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import com.woowacourse.momo.category.domain.Category;
 
 @Getter
-@AllArgsConstructor
 public class GroupSummaryRepositoryResponse {
 
     private Long groupId;
@@ -21,6 +19,34 @@ public class GroupSummaryRepositoryResponse {
     private boolean isClosedEarly;
     private LocalDateTime deadline;
     private String imageName;
+
+    public GroupSummaryRepositoryResponse(Long groupId, String groupName, Long hostId, String hostName,
+                                          Category category, int capacity, int numOfParticipant, boolean isClosedEarly,
+                                          LocalDateTime deadline, String imageName) {
+        this.groupId = groupId;
+        this.groupName = groupName;
+        this.hostId = hostId;
+        this.hostName = hostName;
+        this.category = category;
+        this.capacity = capacity;
+        this.numOfParticipant = numOfParticipant;
+        this.isClosedEarly = isClosedEarly;
+        this.deadline = deadline;
+
+        boolean defaultImage = isDefaultImage(imageName);
+        this.imageName = getGroupImage(imageName, defaultImage);
+    }
+
+    private boolean isDefaultImage(String imageName) {
+        return imageName == null || category.isDefaultImage(imageName);
+    }
+
+    private String getGroupImage(String imageName, boolean defaultImage) {
+        if (defaultImage) {
+            return category.getDefaultImageName();
+        }
+        return imageName;
+    }
 
     public void setImageName(String imageName) {
         this.imageName = imageName;

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupSearchService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupSearchService.java
@@ -114,24 +114,10 @@ public class GroupSearchService {
 
     private List<GroupSummaryRepositoryResponse> convertImageUrl(Page<GroupSummaryRepositoryResponse> groups) {
         for (GroupSummaryRepositoryResponse group : groups.getContent()) {
-            boolean defaultImage = isDefaultImage(group);
-            String imageName = getGroupImage(group, defaultImage);
-
-            String imageUrl = imageProvider.generateGroupImageUrl(imageName, defaultImage);
+            String imageName = group.getImageName();
+            String imageUrl = imageProvider.generateGroupImageUrl(imageName, group.getCategory().isDefaultImage(imageName));
             group.setImageName(imageUrl);
         }
         return groups.getContent();
-    }
-
-    private boolean isDefaultImage(GroupSummaryRepositoryResponse group) {
-        String imageName = group.getImageName();
-        return imageName == null || group.getCategory().isDefaultImage(imageName);
-    }
-
-    private String getGroupImage(GroupSummaryRepositoryResponse group, boolean defaultImage) {
-        if (defaultImage) {
-            return group.getCategory().getDefaultImageName();
-        }
-        return group.getImageName();
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupSearchService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupSearchService.java
@@ -112,12 +112,12 @@ public class GroupSearchService {
         return PageRequest.of(request.getPage(), DEFAULT_PAGE_SIZE);
     }
 
-    private List<GroupSummaryRepositoryResponse> convertImageUrl(Page<GroupSummaryRepositoryResponse> groups) {
-        for (GroupSummaryRepositoryResponse group : groups.getContent()) {
-            String imageName = group.getImageName();
-            String imageUrl = imageProvider.generateGroupImageUrl(imageName, group.getCategory().isDefaultImage(imageName));
-            group.setImageName(imageUrl);
+    private List<GroupSummaryRepositoryResponse> convertImageUrl(Page<GroupSummaryRepositoryResponse> repositoryResponses) {
+        for (GroupSummaryRepositoryResponse repositoryResponse : repositoryResponses.getContent()) {
+            String imageName = repositoryResponse.getImageName();
+            String imageUrl = imageProvider.generateGroupImageUrl(imageName, repositoryResponse.getCategory().isDefaultImage(imageName));
+            repositoryResponse.setImageName(imageUrl);
         }
-        return groups.getContent();
+        return repositoryResponses.getContent();
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupSearchService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupSearchService.java
@@ -108,16 +108,30 @@ public class GroupSearchService {
         return GroupResponseAssembler.groupPageResponse(summaries, groups.hasNext(), request.getPage());
     }
 
+    private Pageable defaultPageable(GroupSearchRequest request) {
+        return PageRequest.of(request.getPage(), DEFAULT_PAGE_SIZE);
+    }
+
     private List<GroupSummaryRepositoryResponse> convertImageUrl(Page<GroupSummaryRepositoryResponse> groups) {
         for (GroupSummaryRepositoryResponse group : groups.getContent()) {
-            String imageName = group.getImageName();
-            String imageUrl = imageProvider.generateGroupImageUrl(imageName, group.getCategory().isDefaultImage(imageName));
+            boolean defaultImage = isDefaultImage(group);
+            String imageName = getGroupImage(group, defaultImage);
+
+            String imageUrl = imageProvider.generateGroupImageUrl(imageName, defaultImage);
             group.setImageName(imageUrl);
         }
         return groups.getContent();
     }
 
-    private Pageable defaultPageable(GroupSearchRequest request) {
-        return PageRequest.of(request.getPage(), DEFAULT_PAGE_SIZE);
+    private boolean isDefaultImage(GroupSummaryRepositoryResponse group) {
+        String imageName = group.getImageName();
+        return imageName == null || group.getCategory().isDefaultImage(imageName);
+    }
+
+    private String getGroupImage(GroupSummaryRepositoryResponse group, boolean defaultImage) {
+        if (defaultImage) {
+            return group.getCategory().getDefaultImageName();
+        }
+        return group.getImageName();
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
@@ -116,6 +116,20 @@ class GroupSearchServiceTest {
         assertThat(actual.getGroups()).hasSize(6);
     }
 
+    @DisplayName("모임 목록 조회 시 모임의 이미지 정보가 없으면 기본 이미지를 반환한다")
+    @Test
+    void findGroupsWithoutGroupImage() {
+        GroupSearchRequest request = new GroupSearchRequest();
+        request.setKeyword("모모의 스터디");
+        request.setPage(0);
+
+        GroupPageResponse actual = groupSearchService.findGroups(request);
+
+        assertThat(actual.getGroups()).hasSize(1);
+        assertThat(actual.getGroups().get(0).getImageUrl())
+                .isEqualTo("http://image.moyeora.site/group/default/thumbnail_study.jpg");
+    }
+
     @DisplayName("키워드를 포함하는 이름의 모임을 조회한다")
     @Test
     void findAllByKeyword() {


### PR DESCRIPTION
## ✨ Issue
- #481 

## 🐞 버그 문제 해결
모임 이미지 정보 조회할 때 이미지 정보가 `null` 일 경우 **모임의 기본 이미지로 대체**한다.
