### PR TITLE
[BE] 모임 썸네일 수정 시 오류가 발생하는 현상

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
@@ -16,6 +16,7 @@ public enum GroupImageErrorCode implements ErrorCode {
     RESPONSE_IS_NULL(400, "GROUP_IMAGE_004", "이미지 서버의 응답값이 null 입니다."),
 
     GROUP_IMAGE_IS_NOT_EXIST(400, "GROUP_IMAGE_005", "모임의 이미지 정보가 존재하지 않습니다."),
+    GROUP_IMAGE_IS_DEFAULT(400, "GROUP_IMAGE_005", "모임의 이미지가 기본 이미지 입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
@@ -11,8 +11,6 @@ public enum GroupImageErrorCode implements ErrorCode {
 
     MEMBER_IS_NOT_HOST(400, "GROUP_IMAGE_001", "모임의 주최자가 아닙니다."),
 
-    MULTIPART_FILE_NAME_IS_NULL(400, "GROUP_IMAGE_002", "이미지 파일의 이름이 null 입니다."),
-
     RESPONSE_IS_4XX(400, "GROUP_IMAGE_003", "이미지 서버에서 4XX 에러가 발생하였습니다."),
     RESPONSE_IS_5XX(400, "GROUP_IMAGE_004", "이미지 서버에서 5XX 에러가 발생하였습니다."),
     RESPONSE_IS_NULL(400, "GROUP_IMAGE_004", "이미지 서버의 응답값이 null 입니다."),

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
@@ -9,11 +9,11 @@ import com.woowacourse.momo.global.exception.exception.ErrorCode;
 @AllArgsConstructor
 public enum GroupImageErrorCode implements ErrorCode {
 
-    MEMBER_IS_NOT_HOST(400, "GROUP_IMAGE_001", "모임의 주최자가 아닙니다."),
+    MEMBER_IS_NOT_HOST(403, "GROUP_IMAGE_001", "모임의 주최자가 아닙니다."),
 
-    RESPONSE_IS_4XX(400, "GROUP_IMAGE_003", "이미지 서버에서 4XX 에러가 발생하였습니다."),
-    RESPONSE_IS_5XX(400, "GROUP_IMAGE_004", "이미지 서버에서 5XX 에러가 발생하였습니다."),
-    RESPONSE_IS_NULL(400, "GROUP_IMAGE_004", "이미지 서버의 응답값이 null 입니다."),
+    RESPONSE_IS_4XX(500, "GROUP_IMAGE_002", "이미지 서버에서 4XX 에러가 발생하였습니다."),
+    RESPONSE_IS_5XX(500, "GROUP_IMAGE_002", "이미지 서버에서 5XX 에러가 발생하였습니다."),
+    RESPONSE_IS_NULL(500, "GROUP_IMAGE_002", "이미지 서버의 응답값이 null 입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
@@ -14,9 +14,6 @@ public enum GroupImageErrorCode implements ErrorCode {
     RESPONSE_IS_4XX(400, "GROUP_IMAGE_003", "이미지 서버에서 4XX 에러가 발생하였습니다."),
     RESPONSE_IS_5XX(400, "GROUP_IMAGE_004", "이미지 서버에서 5XX 에러가 발생하였습니다."),
     RESPONSE_IS_NULL(400, "GROUP_IMAGE_004", "이미지 서버의 응답값이 null 입니다."),
-
-    GROUP_IMAGE_IS_NOT_EXIST(400, "GROUP_IMAGE_005", "모임의 이미지 정보가 존재하지 않습니다."),
-    GROUP_IMAGE_IS_DEFAULT(400, "GROUP_IMAGE_005", "모임의 이미지가 기본 이미지 입니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/GroupImageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/GroupImageService.java
@@ -1,8 +1,5 @@
 package com.woowacourse.momo.storage.service;
 
-import static com.woowacourse.momo.storage.exception.GroupImageErrorCode.GROUP_IMAGE_IS_DEFAULT;
-import static com.woowacourse.momo.storage.exception.GroupImageErrorCode.GROUP_IMAGE_IS_NOT_EXIST;
-
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -19,7 +16,6 @@ import com.woowacourse.momo.member.service.MemberFindService;
 import com.woowacourse.momo.storage.domain.GroupImage;
 import com.woowacourse.momo.storage.domain.GroupImageRepository;
 import com.woowacourse.momo.storage.exception.GroupImageErrorCode;
-import com.woowacourse.momo.storage.exception.GroupImageException;
 import com.woowacourse.momo.storage.support.ImageConnector;
 import com.woowacourse.momo.storage.support.ImageProvider;
 
@@ -54,7 +50,7 @@ public class GroupImageService {
         Group group = groupFindService.findGroup(groupId);
         String defaultImageName = group.getCategory().getDefaultImageName();
 
-        initGroupImage(groupId, defaultImageName);
+        updateGroupImage(groupId, defaultImageName);
     }
 
     private void validateMemberIsHost(Long memberId, Long groupId) {
@@ -83,14 +79,5 @@ public class GroupImageService {
         }
         GroupImage groupImage = new GroupImage(groupId, savedImageName);
         groupImageRepository.save(groupImage);
-    }
-
-    private void initGroupImage(Long groupId, String savedImageName) {
-        GroupImage existedGroupImage = groupImageRepository.findByGroupId(groupId)
-                .orElseThrow(() -> new GroupImageException(GROUP_IMAGE_IS_NOT_EXIST));
-        if (savedImageName.equals(existedGroupImage.getImageName())) {
-            throw new GroupImageException(GROUP_IMAGE_IS_DEFAULT);
-        }
-        existedGroupImage.update(savedImageName);
     }
 }

--- a/backend/src/main/java/com/woowacourse/momo/storage/support/ImageConnector.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/support/ImageConnector.java
@@ -1,12 +1,8 @@
 package com.woowacourse.momo.storage.support;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -67,27 +63,8 @@ public class ImageConnector {
     private MultiValueMap<String, Object> generateBody(String path, MultipartFile multipartFile) {
         MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
         body.add(pathKey, path);
-        body.add(fileKey, createResource(multipartFile));
+        body.add(fileKey, multipartFile.getResource());
         return body;
-    }
-
-    private Resource createResource(MultipartFile multipartFile) {
-        String filename = getFilename(multipartFile);
-        try {
-            File tempFile = new File(filename);
-            multipartFile.transferTo(tempFile);
-            return new FileSystemResource(tempFile);
-        } catch (IOException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
-
-    private String getFilename(MultipartFile multipartFile) {
-        String filename = multipartFile.getOriginalFilename();
-        if (filename == null) {
-            throw new GroupImageException(GroupImageErrorCode.MULTIPART_FILE_NAME_IS_NULL);
-        }
-        return filename;
     }
 
     private ResponseEntity<Void> saveImage(HttpEntity<MultiValueMap<String, Object>> request) {

--- a/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/group/service/GroupSearchServiceTest.java
@@ -127,7 +127,7 @@ class GroupSearchServiceTest {
 
         assertThat(actual.getGroups()).hasSize(1);
         assertThat(actual.getGroups().get(0).getImageUrl())
-                .isEqualTo("http://image.moyeora.site/group/default/thumbnail_study.jpg");
+                .isEqualTo("https://image.moyeora.site/group/default/thumbnail_study.jpg");
     }
 
     @DisplayName("키워드를 포함하는 이름의 모임을 조회한다")

--- a/backend/src/test/java/com/woowacourse/momo/storage/controller/GroupImageControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/controller/GroupImageControllerTest.java
@@ -57,7 +57,7 @@ class GroupImageControllerTest {
     void update() throws Exception {
         Long saveMemberId = saveMember();
         String accessToken = accessToken();
-        String fullPath = "http://image.moyeora.site/group/saved/imageName.png";
+        String fullPath = "https://image.moyeora.site/group/saved/imageName.png";
         BDDMockito.given(groupImageService.update(Mockito.anyLong(), Mockito.anyLong(), Mockito.any()))
                 .willReturn(fullPath);
 

--- a/backend/src/test/java/com/woowacourse/momo/storage/service/GroupImageServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/service/GroupImageServiceTest.java
@@ -69,7 +69,7 @@ class GroupImageServiceTest {
     @DisplayName("모임 이미지 정보를 수정한다")
     @Test
     void update() {
-        String expected = "http://image.moyeora.site/group/saved/imageName.png";
+        String expected = "https://image.moyeora.site/group/saved/imageName.png";
         BDDMockito.given(imageConnector.requestImageSave(Mockito.anyString(), Mockito.any()))
                 .willReturn(expected);
 
@@ -88,7 +88,7 @@ class GroupImageServiceTest {
     @DisplayName("이전에 저장된 이미지가 존재하지 않을 때 모임 이미지 정보를 수정한다")
     @Test
     void updateGroupImageIsNotExist() {
-        String expected = "http://image.moyeora.site/group/saved/imageName.png";
+        String expected = "https://image.moyeora.site/group/saved/imageName.png";
         BDDMockito.given(imageConnector.requestImageSave(Mockito.anyString(), Mockito.any()))
                 .willReturn(expected);
 

--- a/backend/src/test/java/com/woowacourse/momo/storage/service/GroupImageServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/service/GroupImageServiceTest.java
@@ -139,23 +139,35 @@ class GroupImageServiceTest {
         );
     }
 
-    @DisplayName("모임 이미지를 초기화할 때 이전 이미지가 존재하지 않으면 예외가 발생한다")
+    @DisplayName("이전에 저장된 이미지가 존재하지 않을 때 모임 이미지 정보를 초기화하면 기본 이미지 정보가 저장된다")
     @Test
     void initGroupImageIsNotExist() {
-        assertThatThrownBy(() -> groupImageService.init(savedHost.getId(), savedGroup.getId()))
-                .isInstanceOf(MomoException.class)
-                .hasMessage("모임의 이미지 정보가 존재하지 않습니다.");
+        groupImageService.init(savedGroup.getHost().getId(), savedGroup.getId());
+
+        Optional<GroupImage> savedGroupImage = groupImageRepository.findByGroupId(savedGroup.getId());
+        String expected = savedGroup.getCategory().getDefaultImageName();
+        assertThat(savedGroupImage).isPresent();
+        assertAll(
+                () -> assertThat(savedGroupImage.get().getGroupId()).isEqualTo(savedGroup.getId()),
+                () -> assertThat(savedGroupImage.get().getImageName()).isEqualTo(expected)
+        );
     }
 
-    @DisplayName("모임 이미지를 초기화할 때 기본 이미지로 설정되어 있었으면 예외가 발생한다")
+    @DisplayName("기본 이미지가 저장되어 있을 때 모임 이미지를 초기화한다")
     @Test
     void initGroupImageIsDefaultImage() {
         GroupImage groupImage = new GroupImage(savedHost.getId(), savedGroup.getCategory().getDefaultImageName());
         groupImageRepository.save(groupImage);
 
-        assertThatThrownBy(() -> groupImageService.init(savedHost.getId(), savedGroup.getId()))
-                .isInstanceOf(MomoException.class)
-                .hasMessage("모임의 이미지가 기본 이미지 입니다.");
+        groupImageService.init(savedGroup.getHost().getId(), savedGroup.getId());
+
+        Optional<GroupImage> savedGroupImage = groupImageRepository.findByGroupId(savedGroup.getId());
+        String expected = savedGroup.getCategory().getDefaultImageName();
+        assertThat(savedGroupImage).isPresent();
+        assertAll(
+                () -> assertThat(savedGroupImage.get().getGroupId()).isEqualTo(savedGroup.getId()),
+                () -> assertThat(savedGroupImage.get().getImageName()).isEqualTo(expected)
+        );
     }
 
     @DisplayName("모임 이미지를 초기화할 때 주최자가 아니면 예외가 발생한다")


### PR DESCRIPTION
## ✨ Issue
- #488 

## 🐞 버그 해결
이전에 사용했던 FileSystemResource 객체는 실제 존재하는 파일을 요구헀다. 이미지 서버로 전송하던 과정에서 파일을 읽는 과정이 있었고, 존재하는 파일이 아니라서 예외가 발생하였다. 

임의로 Resource 를 만들어 이미지 서버에 보내는 것이 아닌, MultipartFile 에서 제공하는 getResource() 메서드를 사용하였다..
