### PR TITLE
[BE] NOT_SUPPORTED_URI에 예외 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
@@ -5,6 +5,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.woowacourse.momo.global.exception.dto.response.ExceptionResponse;
@@ -29,7 +30,7 @@ public class ControllerAdvice {
         return convert(GlobalErrorCode.VALIDATION_ERROR);
     }
 
-    @ExceptionHandler(NoHandlerFoundException.class)
+    @ExceptionHandler({NoHandlerFoundException.class, MethodArgumentTypeMismatchException.class})
     public ResponseEntity<ExceptionResponse> notSupportedUriException() {
         return convert(GlobalErrorCode.NOT_SUPPORTED_URI_ERROR);
     }


### PR DESCRIPTION
### 관련 이슈
- #503

### 변경 사항
- `ControllerAdvice#notSupportedUriException` 에 `MethodArgumentTypeMismatchException` 클래스 등록


### 적용 확인
<img width="451" alt="스크린샷 2022-10-20 오후 6 29 55" src="https://user-images.githubusercontent.com/22176552/196911806-c4f02a26-a534-44b5-b3f5-0bd9d0794780.png">
<img width="258" alt="스크린샷 2022-10-20 오후 6 31 27" src="https://user-images.githubusercontent.com/22176552/196912145-1b45069e-4752-4d71-879e-0a8b2bc3cd25.png">