### PR TITLE
[FE] 모임 상세 정보 타입에서 id 제거

### DIFF
--- a/frontend/src/apis/request/group.ts
+++ b/frontend/src/apis/request/group.ts
@@ -9,11 +9,12 @@ import {
   GroupList,
   CategoryType,
   SelectableGroup,
+  GroupSummary,
 } from 'types/data';
 import { makeUrl } from 'utils/url';
 
 interface GroupIdResponse {
-  groupId: GroupDetailData['id'];
+  groupId: GroupSummary['id'];
 }
 
 const makeGroupData = ({
@@ -90,7 +91,7 @@ const requestEditGroup = (
     location,
     description,
   }: CreateGroupData,
-  id: GroupDetailData['id'],
+  id: GroupSummary['id'],
 ) => {
   const data = makeGroupData({
     name,
@@ -117,17 +118,14 @@ const requestEditGroup = (
     });
 };
 
-const requestEditThumbnail = (
-  id: GroupDetailData['id'],
-  formData: FormData,
-) => {
+const requestEditThumbnail = (id: GroupSummary['id'], formData: FormData) => {
   return axiosWithAccessToken.post(
     `${API_PATH.GROUP}/${id}/thumbnail`,
     formData,
   );
 };
 
-const requestResetThumbnail = (id: GroupDetailData['id']) => {
+const requestResetThumbnail = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.delete(`${API_PATH.GROUP}/${id}/thumbnail`);
 };
 
@@ -179,43 +177,43 @@ const requestGroups =
       .then(response => response.data);
   };
 
-const requestGroupDetail = (id: GroupDetailData['id']) => {
+const requestGroupDetail = (id: GroupSummary['id']) => {
   return axiosWithAccessToken
     .get<GroupDetailData>(`${API_PATH.GROUP}/${id}`)
     .then(response => response.data);
 };
 
-const requestDeleteGroup = (id: GroupDetailData['id']) => {
+const requestDeleteGroup = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.delete(`${API_PATH.GROUP}/${id}`);
 };
 
-const requestGroupParticipants = (id: GroupDetailData['id']) => {
+const requestGroupParticipants = (id: GroupSummary['id']) => {
   return axios
     .get<GroupParticipants>(`${API_PATH.GROUP}/${id}${API_PATH.PARTICIPANTS}`)
     .then(response => response.data);
 };
 
-const requestJoinGroup = (id: GroupDetailData['id']) => {
+const requestJoinGroup = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.post(
     `${API_PATH.GROUP}/${id}${API_PATH.PARTICIPANTS}`,
   );
 };
 
-const requestExitGroup = (id: GroupDetailData['id']) => {
+const requestExitGroup = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.delete(
     `${API_PATH.GROUP}/${id}${API_PATH.PARTICIPANTS}`,
   );
 };
 
-const requestCloseGroup = (id: GroupDetailData['id']) => {
+const requestCloseGroup = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.post(`${API_PATH.GROUP}/${id}${API_PATH.CLOSE}`);
 };
 
-const requestLikeGroup = (id: GroupDetailData['id']) => {
+const requestLikeGroup = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.post(`${API_PATH.GROUP}/${id}${API_PATH.LIKE}`);
 };
 
-const requestUnlikeGroup = (id: GroupDetailData['id']) => {
+const requestUnlikeGroup = (id: GroupSummary['id']) => {
   return axiosWithAccessToken.delete(`${API_PATH.GROUP}/${id}${API_PATH.LIKE}`);
 };
 

--- a/frontend/src/components/ImageDropBox/index.tsx
+++ b/frontend/src/components/ImageDropBox/index.tsx
@@ -14,15 +14,11 @@ import useHandleError from 'hooks/useHandleError';
 import useModal from 'hooks/useModal';
 import useSnackbar from 'hooks/useSnackbar';
 import { modalState } from 'store/states';
-import { GroupDetailData } from 'types/data';
+import { GroupSummary } from 'types/data';
 
 import * as S from './index.styled';
 
-interface ImageDropBoxProps {
-  id: GroupDetailData['id'];
-}
-
-function ImageDropBox({ id }: ImageDropBoxProps) {
+function ImageDropBox({ id }: Pick<GroupSummary, 'id'>) {
   const [file, setFile] = useState<File | null>();
   const [isDragOver, setIsDragOver] = useState(false);
 

--- a/frontend/src/pages/Detail/index.tsx
+++ b/frontend/src/pages/Detail/index.tsx
@@ -45,9 +45,9 @@ function Detail() {
   return (
     <>
       {document.body.clientWidth > theme.breakpoints.md ? (
-        <Desktop data={data} participants={participants} />
+        <Desktop id={Number(id)} data={data} participants={participants} />
       ) : (
-        <Mobile data={data} participants={participants} />
+        <Mobile id={Number(id)} data={data} participants={participants} />
       )}
       <ImageDropBox id={Number(id)} />
     </>

--- a/frontend/src/pages/Detail/versions/Desktop/Content/EditMode/index.tsx
+++ b/frontend/src/pages/Detail/versions/Desktop/Content/EditMode/index.tsx
@@ -16,18 +16,19 @@ import useMount from 'hooks/useMount';
 import useSnackbar from 'hooks/useSnackbar';
 import { validateGroupData } from 'pages/Create/validate';
 import { groupDetailState } from 'store/states';
-import { GroupDetailData } from 'types/data';
+import { GroupDetailData, GroupSummary } from 'types/data';
 import { getNewDateString } from 'utils/date';
 
 import ControlButton from './ControlButton';
 import * as S from './index.styled';
 
 interface EditModeProps {
+  id: GroupSummary['id'];
   data: GroupDetailData;
   finishEditMode: () => void;
 }
 
-function EditMode({ data, finishEditMode }: EditModeProps) {
+function EditMode({ id, data, finishEditMode }: EditModeProps) {
   const categories = useCategory();
   const resetGroupData = useResetRecoilState(groupDetailState);
 
@@ -101,7 +102,7 @@ function EditMode({ data, finishEditMode }: EditModeProps) {
       return;
     }
 
-    requestEditGroup(groupData, data.id)
+    requestEditGroup(groupData, id)
       .then(() => {
         resetGroupData();
 

--- a/frontend/src/pages/Detail/versions/Desktop/Content/index.tsx
+++ b/frontend/src/pages/Detail/versions/Desktop/Content/index.tsx
@@ -10,7 +10,7 @@ import {
   Title,
 } from 'pages/Detail/versions/@shared/index.styled';
 import { loginState } from 'store/states';
-import { GroupDetailData, GroupParticipants } from 'types/data';
+import { GroupDetailData, GroupParticipants, GroupSummary } from 'types/data';
 import { convertDeadlineToRemainTime } from 'utils/date';
 
 import ControlButton from '../ControlButton';
@@ -23,11 +23,12 @@ import Right from './Right';
 const svgSize = 20;
 
 interface ContentProps {
+  id: GroupSummary['id'];
   data: GroupDetailData;
   participants: GroupParticipants;
 }
 
-function Content({ data, participants }: ContentProps) {
+function Content({ id, data, participants }: ContentProps) {
   const { user } = useRecoilValue(loginState);
   const categories = useCategory();
 
@@ -42,7 +43,7 @@ function Content({ data, participants }: ContentProps) {
   };
 
   if (mode === 'edit') {
-    return <EditMode data={data} finishEditMode={finishEditMode} />;
+    return <EditMode id={id} data={data} finishEditMode={finishEditMode} />;
   }
 
   return (
@@ -71,7 +72,7 @@ function Content({ data, participants }: ContentProps) {
           )}
         </S.Header>
         <ControlButton
-          id={data.id}
+          id={id}
           host={data.host}
           capacity={data.capacity}
           finished={data.finished}
@@ -87,7 +88,7 @@ function Content({ data, participants }: ContentProps) {
           schedules={data.schedules}
           participants={participants}
         />
-        <LikeButton id={data.id} like={data.like} />
+        <LikeButton id={id} like={data.like} />
       </S.ContentContainer>
     </S.Container>
   );

--- a/frontend/src/pages/Detail/versions/Desktop/ControlButton/index.tsx
+++ b/frontend/src/pages/Detail/versions/Desktop/ControlButton/index.tsx
@@ -14,12 +14,12 @@ import { BROWSER_PATH } from 'constants/path';
 import useHandleError from 'hooks/useHandleError';
 import useSnackbar from 'hooks/useSnackbar';
 import { loginState } from 'store/states';
-import { GroupDetailData, GroupParticipants } from 'types/data';
+import { GroupParticipants, GroupSummary } from 'types/data';
 
 import * as S from './index.styled';
 
 interface ControlButtonProps
-  extends Pick<GroupDetailData, 'id' | 'host' | 'capacity' | 'finished'> {
+  extends Pick<GroupSummary, 'id' | 'host' | 'capacity' | 'finished'> {
   participants: GroupParticipants;
 }
 

--- a/frontend/src/pages/Detail/versions/Desktop/index.tsx
+++ b/frontend/src/pages/Detail/versions/Desktop/index.tsx
@@ -4,7 +4,7 @@ import { CameraSVG } from 'assets/svg';
 import useModal from 'hooks/useModal';
 import { loginState } from 'store/states';
 import theme from 'styles/theme';
-import { GroupDetailData, GroupParticipants } from 'types/data';
+import { GroupDetailData, GroupParticipants, GroupSummary } from 'types/data';
 
 import { Image, SvgWrapper } from '../@shared/index.styled';
 import Content from './Content';
@@ -12,11 +12,12 @@ import Content from './Content';
 const svgSize = 20;
 
 interface DesktopProps {
+  id: GroupSummary['id'];
   data: GroupDetailData;
   participants: GroupParticipants;
 }
 
-function Desktop({ data, participants }: DesktopProps) {
+function Desktop({ id, data, participants }: DesktopProps) {
   const { user } = useRecoilValue(loginState);
 
   const { showThumbnailModal } = useModal();
@@ -31,7 +32,7 @@ function Desktop({ data, participants }: DesktopProps) {
           <CameraSVG width={svgSize} fill={theme.colors.white001} />
         </SvgWrapper>
       )}
-      <Content data={data} participants={participants} />
+      <Content id={id} data={data} participants={participants} />
     </>
   );
 }

--- a/frontend/src/pages/Detail/versions/Mobile/Content/EditMode/index.tsx
+++ b/frontend/src/pages/Detail/versions/Mobile/Content/EditMode/index.tsx
@@ -16,18 +16,19 @@ import useMount from 'hooks/useMount';
 import useSnackbar from 'hooks/useSnackbar';
 import { validateGroupData } from 'pages/Create/validate';
 import { groupDetailState } from 'store/states';
-import { GroupDetailData } from 'types/data';
+import { GroupDetailData, GroupSummary } from 'types/data';
 import { getNewDateString } from 'utils/date';
 
 import ControlButton from './ControlButton';
 import * as S from './index.styled';
 
 interface EditModeProps {
+  id: GroupSummary['id'];
   data: GroupDetailData;
   finishEditMode: () => void;
 }
 
-function EditMode({ data, finishEditMode }: EditModeProps) {
+function EditMode({ id, data, finishEditMode }: EditModeProps) {
   const categories = useCategory();
   const resetGroupData = useResetRecoilState(groupDetailState);
 
@@ -100,7 +101,7 @@ function EditMode({ data, finishEditMode }: EditModeProps) {
       return;
     }
 
-    requestEditGroup(groupData, data.id)
+    requestEditGroup(groupData, id)
       .then(() => {
         resetGroupData();
 

--- a/frontend/src/pages/Detail/versions/Mobile/Content/index.tsx
+++ b/frontend/src/pages/Detail/versions/Mobile/Content/index.tsx
@@ -14,7 +14,7 @@ import {
   Title,
 } from 'pages/Detail/versions/@shared/index.styled';
 import { loginState } from 'store/states';
-import { GroupDetailData, GroupParticipants } from 'types/data';
+import { GroupDetailData, GroupParticipants, GroupSummary } from 'types/data';
 import { convertDeadlineToRemainTime } from 'utils/date';
 
 import ControlButton from '../ControlButton';
@@ -25,11 +25,12 @@ import * as S from './index.styled';
 const svgSize = 20;
 
 interface ContentProps {
+  id: GroupSummary['id'];
   data: GroupDetailData;
   participants: GroupParticipants;
 }
 
-function Content({ data, participants }: ContentProps) {
+function Content({ id, data, participants }: ContentProps) {
   const { user } = useRecoilValue(loginState);
   const categories = useCategory();
 
@@ -44,7 +45,7 @@ function Content({ data, participants }: ContentProps) {
   };
 
   if (mode === 'edit') {
-    return <EditMode data={data} finishEditMode={finishEditMode} />;
+    return <EditMode id={id} data={data} finishEditMode={finishEditMode} />;
   }
 
   return (
@@ -65,7 +66,7 @@ function Content({ data, participants }: ContentProps) {
             </Category>
           </S.TitleContainer>
           <S.SideMenu>
-            <LikeButton id={data.id} like={data.like} />
+            <LikeButton id={id} like={data.like} />
             {user?.id === data.host.id && !data.finished && (
               <PencilSVG
                 width={svgSize}
@@ -88,7 +89,7 @@ function Content({ data, participants }: ContentProps) {
       </S.ContentContainer>
       <S.ControlContainer>
         <ControlButton
-          id={data.id}
+          id={id}
           host={data.host}
           capacity={data.capacity}
           finished={data.finished}

--- a/frontend/src/pages/Detail/versions/Mobile/ControlButton/index.tsx
+++ b/frontend/src/pages/Detail/versions/Mobile/ControlButton/index.tsx
@@ -14,12 +14,12 @@ import { BROWSER_PATH } from 'constants/path';
 import useHandleError from 'hooks/useHandleError';
 import useSnackbar from 'hooks/useSnackbar';
 import { loginState } from 'store/states';
-import { GroupDetailData, GroupParticipants } from 'types/data';
+import { GroupParticipants, GroupSummary } from 'types/data';
 
 import * as S from './index.styled';
 
 interface ControlButtonProps
-  extends Pick<GroupDetailData, 'id' | 'host' | 'capacity' | 'finished'> {
+  extends Pick<GroupSummary, 'id' | 'host' | 'capacity' | 'finished'> {
   participants: GroupParticipants;
 }
 

--- a/frontend/src/pages/Detail/versions/Mobile/index.tsx
+++ b/frontend/src/pages/Detail/versions/Mobile/index.tsx
@@ -4,7 +4,7 @@ import { CameraSVG } from 'assets/svg';
 import useModal from 'hooks/useModal';
 import { loginState } from 'store/states';
 import theme from 'styles/theme';
-import { GroupDetailData, GroupParticipants } from 'types/data';
+import { GroupDetailData, GroupParticipants, GroupSummary } from 'types/data';
 
 import { Image, SvgWrapper } from '../@shared/index.styled';
 import Content from './Content';
@@ -12,11 +12,12 @@ import Content from './Content';
 const svgSize = 20;
 
 interface MobileProps {
+  id: GroupSummary['id'];
   data: GroupDetailData;
   participants: GroupParticipants;
 }
 
-function Mobile({ data, participants }: MobileProps) {
+function Mobile({ id, data, participants }: MobileProps) {
   const { user } = useRecoilValue(loginState);
 
   const { showThumbnailModal } = useModal();
@@ -31,7 +32,7 @@ function Mobile({ data, participants }: MobileProps) {
           <CameraSVG width={svgSize} fill={theme.colors.white001} />
         </SvgWrapper>
       )}
-      <Content data={data} participants={participants} />
+      <Content id={id} data={data} participants={participants} />
     </>
   );
 }

--- a/frontend/src/store/states.ts
+++ b/frontend/src/store/states.ts
@@ -28,7 +28,6 @@ const loginState = atom<LoginState>({
 const groupDetailState = atom<GroupDetailData>({
   key: 'groupDetailState',
   default: {
-    id: -1,
     name: '',
     host: {
       id: -1,

--- a/frontend/src/types/data.ts
+++ b/frontend/src/types/data.ts
@@ -24,7 +24,6 @@ export interface DurationDate {
 }
 
 export interface GroupDetailData {
-  id: number;
   name: string;
   host: {
     id: number;
@@ -68,7 +67,6 @@ export interface GroupList {
 export interface GroupSummary
   extends Pick<
     GroupDetailData,
-    | 'id'
     | 'name'
     | 'host'
     | 'categoryId'
@@ -78,6 +76,7 @@ export interface GroupSummary
     | 'like'
     | 'imageUrl'
   > {
+  id: number;
   numOfParticipant: number;
 }
 


### PR DESCRIPTION
## Issue

- #501 

## Description (optional)

- 모임 상세 정보 응답에는 id 값이 없으나, 프론트엔드 코드에는 존재하는 것을 확인하여 이를 제거하고자 함
- GroupDetailData 타입에서 id를 제거하고 GroupSummary 타입에 id 추가

closed #501 