### PR TITLE
[BE] 동시성 문제 해결

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/search/GroupSearchRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/search/GroupSearchRepository.java
@@ -3,6 +3,9 @@ package com.woowacourse.momo.group.domain.search;
 import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.LockModeType;
+
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +15,7 @@ import com.woowacourse.momo.member.domain.Member;
 
 public interface GroupSearchRepository extends Repository<Group, Long>, GroupSearchRepositoryCustom {
 
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     Optional<Group> findById(Long id);
 
     @Query("select g from Group g "

--- a/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
@@ -22,7 +22,7 @@ public class ParticipateService {
     private final GroupFindService groupFindService;
 
     @Transactional
-    public synchronized void participate(Long groupId, Long memberId) {
+    public void participate(Long groupId, Long memberId) {
         Group group = groupFindService.findGroup(groupId);
         Member member = memberFindService.findMember(memberId);
 
@@ -30,7 +30,7 @@ public class ParticipateService {
     }
 
     public List<MemberResponse> findParticipants(Long groupId) {
-        Group group = groupFindService.findGroup(groupId);
+        Group group = groupFindService.findByIdWithHostAndSchedule(groupId);
         List<Member> participants = group.getParticipants();
 
         return MemberResponseAssembler.memberResponses(participants);


### PR DESCRIPTION
### 관련 이슈
- https://github.com/woowacourse-teams/2022-momo/issues/498

### 변경 사항
- `ParticipateService#participate`에 지정되어 있던 synchronized 키워드를 제거하고
- `GroupSearchRepository#findById`에 `@Lock(value = LockModeType.PESSIMISTIC_WRITE)` 비관적 lock 지정함
- `ParticipateService#findParticipants`에서 `GroupFindService#findByIdWithHostAndSchedule`를 사용하도록 수정

