### PR TITLE
[BE] 조회 쿼리 개선 

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/participant/ParticipantRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/participant/ParticipantRepository.java
@@ -18,4 +18,7 @@ public interface ParticipantRepository extends Repository<Participant, Long> {
     @Modifying
     @Query("delete from Participant p where p.member.id = :memberId and p.group in (:groups)")
     void deleteAllByMemberIdInGroups(@Param("memberId") Long memberId, @Param("groups") List<Group> groups);
+
+    @Query("select distinct p.group.id from Participant p where p.member.id = :memberId")
+    List<Long> findGroupIdWhichParticipated(@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/domain/search/GroupSearchRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/search/GroupSearchRepository.java
@@ -26,8 +26,9 @@ public interface GroupSearchRepository extends Repository<Group, Long>, GroupSea
 
     @Query("SELECT g FROM Group g "
             + "WHERE g.participants.host = :member "
-            + "OR ( :member IN (SELECT p.member.id FROM Participant p WHERE p.group = g) )")
-    List<Group> findParticipatedGroups(@Param("member") Member member);
+            + "OR g.id IN :participatedGroupIds")
+    List<Group> findParticipatedGroups(@Param("member") Member member,
+                                       @Param("participatedGroupIds") List<Long> participatedGroupIds);
 
     boolean existsById(Long id);
 }

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.woowacourse.momo.group.domain.Group;
+import com.woowacourse.momo.group.domain.participant.ParticipantRepository;
 import com.woowacourse.momo.group.domain.search.GroupSearchRepository;
 import com.woowacourse.momo.group.exception.GroupException;
 import com.woowacourse.momo.member.domain.Member;
@@ -20,6 +21,7 @@ import com.woowacourse.momo.member.domain.Member;
 public class GroupFindService {
 
     private final GroupSearchRepository groupSearchRepository;
+    private final ParticipantRepository participantRepository;
 
     public Group findGroup(Long id) {
         return groupSearchRepository.findById(id)
@@ -32,6 +34,7 @@ public class GroupFindService {
     }
 
     public List<Group> findParticipatedGroups(Member member) {
-        return groupSearchRepository.findParticipatedGroups(member);
+        List<Long> participatedGroupIds = participantRepository.findGroupIdWhichParticipated(member.getId());
+        return groupSearchRepository.findParticipatedGroups(member, participatedGroupIds);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/member/service/MemberValidatorTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/member/service/MemberValidatorTest.java
@@ -35,7 +35,7 @@ class MemberValidatorTest {
                 .hasMessage(MEMBER_NOT_EXIST.getMessage());
     }
 
-    @DisplayName("삭제된 않는 회원 id가 아니면 예외를 발생시킨다")
+    @DisplayName("삭제되지 않은 회원 id가 아니면 예외를 발생시킨다")
     @Test
     void validateDeletedMember() {
         Member member = memberRepository.save(MOMO.toMember());


### PR DESCRIPTION
전체적으로 쿼리가 다 깔끔한데.. groupfindservice의 쿼리 하나만 성능이 안좋게 나가고 있는것 같았습니다.
기존 쿼리의 성능은 다음과 같습니다. 두 실행결과 모두 동일한 쿼리를 사용하였으며 100만건의 데이터 기준으로 성능을 측정하였습니다.
변경점은 서브쿼리 분리입니다~

로직 적용 전

![image](https://user-images.githubusercontent.com/76891875/198859447-2e51c867-dab3-4120-88bd-c8feb6748882.png)

로직 적용 후

![image](https://user-images.githubusercontent.com/76891875/198859471-13c6eafb-f885-47a7-9039-ef10d634baf3.png)

관련된 내용은 개인 블로그에 올려두었습니다. >> https://nbalance97.tistory.com/335
