### PR TITLE
[BE] 비관적 락 개선

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/group/domain/search/GroupSearchRepository.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/domain/search/GroupSearchRepository.java
@@ -15,8 +15,11 @@ import com.woowacourse.momo.member.domain.Member;
 
 public interface GroupSearchRepository extends Repository<Group, Long>, GroupSearchRepositoryCustom {
 
-    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     Optional<Group> findById(Long id);
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select g from Group g where g.id = :id")
+    Optional<Group> findByIdForUpdate(@Param("id") Long id);
 
     @Query("select g from Group g "
             + "left join fetch g.calendar.schedules "

--- a/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/GroupFindService.java
@@ -26,6 +26,11 @@ public class GroupFindService {
                 .orElseThrow(() -> new GroupException(NOT_EXIST));
     }
 
+    public Group findByIdForUpdate(Long id) {
+        return groupSearchRepository.findByIdForUpdate(id)
+                .orElseThrow(() -> new GroupException(NOT_EXIST));
+    }
+
     public Group findByIdWithHostAndSchedule(Long id) {
         return groupSearchRepository.findByIdWithHostAndSchedule(id)
                 .orElseThrow(() -> new GroupException(NOT_EXIST));

--- a/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
+++ b/backend/src/main/java/com/woowacourse/momo/group/service/ParticipateService.java
@@ -23,14 +23,14 @@ public class ParticipateService {
 
     @Transactional
     public void participate(Long groupId, Long memberId) {
-        Group group = groupFindService.findGroup(groupId);
+        Group group = groupFindService.findByIdForUpdate(groupId);
         Member member = memberFindService.findMember(memberId);
 
         group.participate(member);
     }
 
     public List<MemberResponse> findParticipants(Long groupId) {
-        Group group = groupFindService.findByIdWithHostAndSchedule(groupId);
+        Group group = groupFindService.findGroup(groupId);
         List<Member> participants = group.getParticipants();
 
         return MemberResponseAssembler.memberResponses(participants);


### PR DESCRIPTION
보편적으로 사용하는 `findById`가 아닌, 명시적으로 작성된 `findByIdForUpdate`를 사용하는 경우 비관적락이 적용되도록 로직 변경

- https://github.com/woowacourse-teams/2022-momo/issues/538