### PR TITLE
[BE] 이미지 업로드 파일 크기 제한 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
@@ -6,11 +6,11 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.woowacourse.momo.global.exception.dto.response.ExceptionResponse;
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
-import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.support.logging.UnhandledErrorLogging;
 
@@ -28,6 +28,11 @@ public class ControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException() {
         return convert(GlobalErrorCode.VALIDATION_ERROR);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ExceptionResponse> handleMaxUploadSizeExceededException() {
+        return convert(GlobalErrorCode.MAX_UPLOAD_SIZE_FILE_ERROR);
     }
 
     @ExceptionHandler({NoHandlerFoundException.class, MethodArgumentTypeMismatchException.class})

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/ControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 
 import com.woowacourse.momo.global.exception.dto.response.ExceptionResponse;
 import com.woowacourse.momo.global.exception.exception.ErrorCode;
+import com.woowacourse.momo.global.exception.exception.GlobalErrorCode;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.support.logging.UnhandledErrorLogging;
 

--- a/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/exception/exception/GlobalErrorCode.java
@@ -9,6 +9,9 @@ public enum GlobalErrorCode implements ErrorCode {
 
     NOT_SUPPORTED_URI_ERROR(404, "NOT_SUPPORTED_URI", "지원하지 않는 URI 요청입니다."),
     NOT_SUPPORTED_METHOD_ERROR(405, "NOT_SUPPORTED_METHOD", "지원하지 않는 Method 요청입니다."),
+
+    MAX_UPLOAD_SIZE_FILE_ERROR(400, "MAX_UPLOAD_SIZE_FILE", "요청한 파일의 크기가 제한된 크기보다 큽니다."),
+
     VALIDATION_ERROR(400, "VALIDATION_001", "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(500, "SERVER_001", "내부 서버 오류입니다."),
     ;

--- a/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/exception/GroupImageErrorCode.java
@@ -14,6 +14,8 @@ public enum GroupImageErrorCode implements ErrorCode {
     RESPONSE_IS_4XX(500, "GROUP_IMAGE_002", "이미지 서버에서 4XX 에러가 발생하였습니다."),
     RESPONSE_IS_5XX(500, "GROUP_IMAGE_002", "이미지 서버에서 5XX 에러가 발생하였습니다."),
     RESPONSE_IS_NULL(500, "GROUP_IMAGE_002", "이미지 서버의 응답값이 null 입니다."),
+
+    FILE_SIZE_IS_LARGE(400, "GROUP_IMAGE_003", "이미지 파일의 크기가 기준보다 큽니다."),
     ;
 
     private final int statusCode;

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/GroupImageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/GroupImageService.java
@@ -16,6 +16,7 @@ import com.woowacourse.momo.member.service.MemberFindService;
 import com.woowacourse.momo.storage.domain.GroupImage;
 import com.woowacourse.momo.storage.domain.GroupImageRepository;
 import com.woowacourse.momo.storage.exception.GroupImageErrorCode;
+import com.woowacourse.momo.storage.exception.GroupImageException;
 import com.woowacourse.momo.storage.support.ImageConnector;
 import com.woowacourse.momo.storage.support.ImageProvider;
 
@@ -30,8 +31,12 @@ public class GroupImageService {
     private final ImageConnector imageConnector;
     private final ImageProvider imageProvider;
 
+    private static final int BYTES_FROM_ONE_MB = 1_000_000;
+    private static final int MAXIMUM_FILE_SIZE = 10;
+
     @Transactional
     public String update(Long memberId, Long groupId, MultipartFile multipartFile) {
+        validateFileSizeIsValid(multipartFile);
         validateMemberIsHost(memberId, groupId);
         validateGroupIsProceeding(groupId);
 
@@ -51,6 +56,12 @@ public class GroupImageService {
         String defaultImageName = group.getCategory().getDefaultImageName();
 
         updateGroupImage(groupId, defaultImageName);
+    }
+
+    private void validateFileSizeIsValid(MultipartFile multipartFile) {
+        if (multipartFile.getSize() > MAXIMUM_FILE_SIZE * BYTES_FROM_ONE_MB) {
+            throw new GroupImageException(GroupImageErrorCode.FILE_SIZE_IS_LARGE);
+        }
     }
 
     private void validateMemberIsHost(Long memberId, Long groupId) {

--- a/backend/src/main/java/com/woowacourse/momo/storage/service/GroupImageService.java
+++ b/backend/src/main/java/com/woowacourse/momo/storage/service/GroupImageService.java
@@ -59,9 +59,13 @@ public class GroupImageService {
     }
 
     private void validateFileSizeIsValid(MultipartFile multipartFile) {
-        if (multipartFile.getSize() > MAXIMUM_FILE_SIZE * BYTES_FROM_ONE_MB) {
+        if (multipartFile.getSize() > byteToMegaByte(MAXIMUM_FILE_SIZE)) {
             throw new GroupImageException(GroupImageErrorCode.FILE_SIZE_IS_LARGE);
         }
+    }
+
+    private int byteToMegaByte(int megaByte) {
+        return megaByte * BYTES_FROM_ONE_MB;
     }
 
     private void validateMemberIsHost(Long memberId, Long groupId) {

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -11,6 +11,11 @@ spring:
   mvc.throw-exception-if-no-handler-found: true
   web.resources.add-mappings: false
 
+  servlet:
+    multipart:
+      max-file-size: 1GB
+      max-request-size: -1
+
 momo-log:
   slack: false
   file: false

--- a/backend/src/test/java/com/woowacourse/momo/fixture/ImageFixture.java
+++ b/backend/src/test/java/com/woowacourse/momo/fixture/ImageFixture.java
@@ -15,16 +15,16 @@ public enum ImageFixture {
     private final String name;
     private final String originalFilename;
     private final String mediaType;
-    private final byte[] size;
+    private final byte[] content;
 
-    ImageFixture(String name, String originalFilename, String mediaType, byte[] size) {
+    ImageFixture(String name, String originalFilename, String mediaType, byte[] content) {
         this.name = name;
         this.originalFilename = originalFilename;
         this.mediaType = mediaType;
-        this.size = size;
+        this.content = content;
     }
 
     public MockMultipartFile toMultipartFile() {
-        return new MockMultipartFile(name, originalFilename, mediaType, size);
+        return new MockMultipartFile(name, originalFilename, mediaType, content);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/fixture/ImageFixture.java
+++ b/backend/src/test/java/com/woowacourse/momo/fixture/ImageFixture.java
@@ -5,22 +5,26 @@ import org.springframework.mock.web.MockMultipartFile;
 
 public enum ImageFixture {
 
-    PNG_IMAGE("file", "asdf.png", MediaType.IMAGE_PNG_VALUE, "asdf".getBytes())
+    PNG_IMAGE("file", "asdf.png", MediaType.IMAGE_PNG_VALUE, "asdf".getBytes()),
+    /**
+     * 1,024 * 1,024 B = 1 MB
+     */
+    LARGE_IMAGE("file", "large.png", MediaType.IMAGE_PNG_VALUE, new byte[1024 * 1024 * 100]),
     ;
 
     private final String name;
     private final String originalFilename;
     private final String mediaType;
-    private final byte[] content;
+    private final byte[] size;
 
-    ImageFixture(String name, String originalFilename, String mediaType, byte[] content) {
+    ImageFixture(String name, String originalFilename, String mediaType, byte[] size) {
         this.name = name;
         this.originalFilename = originalFilename;
         this.mediaType = mediaType;
-        this.content = content;
+        this.size = size;
     }
 
     public MockMultipartFile toMultipartFile() {
-        return new MockMultipartFile(name, originalFilename, mediaType, content);
+        return new MockMultipartFile(name, originalFilename, mediaType, size);
     }
 }

--- a/backend/src/test/java/com/woowacourse/momo/storage/service/GroupImageServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/storage/service/GroupImageServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.woowacourse.momo.auth.support.SHA256Encoder;
+import com.woowacourse.momo.fixture.ImageFixture;
 import com.woowacourse.momo.global.exception.exception.MomoException;
 import com.woowacourse.momo.group.domain.Group;
 import com.woowacourse.momo.group.domain.GroupRepository;
@@ -31,7 +32,6 @@ import com.woowacourse.momo.member.domain.UserId;
 import com.woowacourse.momo.member.domain.UserName;
 import com.woowacourse.momo.storage.domain.GroupImage;
 import com.woowacourse.momo.storage.domain.GroupImageRepository;
-import com.woowacourse.momo.storage.exception.GroupImageException;
 import com.woowacourse.momo.storage.support.ImageConnector;
 
 @Transactional
@@ -100,6 +100,16 @@ class GroupImageServiceTest {
                 () -> assertThat(actual).isEqualTo(expected),
                 () -> assertThat(savedGroupImage.get().getImageName()).isEqualTo("imageName.png")
         );
+    }
+
+    @DisplayName("허용할 수 있는 이미지 크기보다 큰 이미지로 수정할 경우 예외가 발생한다")
+    @Test
+    void updateLargeGroupImage() {
+        MockMultipartFile invalidImage = ImageFixture.LARGE_IMAGE.toMultipartFile();
+
+        assertThatThrownBy(() -> groupImageService.update(savedGroup.getHost().getId(), savedGroup.getId(), invalidImage))
+                .isInstanceOf(MomoException.class)
+                .hasMessage("이미지 파일의 크기가 기준보다 큽니다.");
     }
 
     @DisplayName("모임 이미지를 수정할 때 주최자가 아니면 예외가 발생한다")


### PR DESCRIPTION
## ✨ Issue
- #524 

## 🚀 기능 구현
- 스프링에서 제한하는 파일 및 요청 크기 제한 설정
  - 파일 : 1GB (default 1MB)
  - 요청 메시지 : -1 (제한 없음, default 10MB)
- 모임 썸네일(이미지)에 대한 파일 크기 제한 설정
  - 파일 : 10MB

## 📝 노션 정리
- https://fishy-chopper-4a0.notion.site/d93bb1f849434381a2e8d763968b0d39

---

파일 및 요청 제한을 제가 임의로 설정해두었는데, 혹시 설정값을 변경하고 싶다면 리뷰 부탁드립니다!