### PR TITLE
[BE] 찜하기 데이터 삭제 관련 이벤트 처리방식을 비동기로 변경

### DIFF
--- a/backend/src/main/java/com/woowacourse/momo/favorite/event/FavoriteDeleteEventListener.java
+++ b/backend/src/main/java/com/woowacourse/momo/favorite/event/FavoriteDeleteEventListener.java
@@ -1,9 +1,9 @@
 package com.woowacourse.momo.favorite.event;
 
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,13 +18,13 @@ public class FavoriteDeleteEventListener {
 
     private final FavoriteRepository favoriteRepository;
 
-    @EventListener
+    @TransactionalEventListener
     @Async
     public void deleteGroup(GroupDeleteEvent event) {
         favoriteRepository.deleteAllByGroupId(event.getId());
     }
 
-    @EventListener
+    @TransactionalEventListener
     @Async
     public void deleteMember(MemberDeleteEvent event) {
         favoriteRepository.deleteAllByMemberId(event.getId());

--- a/backend/src/main/java/com/woowacourse/momo/favorite/event/FavoriteDeleteEventListener.java
+++ b/backend/src/main/java/com/woowacourse/momo/favorite/event/FavoriteDeleteEventListener.java
@@ -1,7 +1,9 @@
 package com.woowacourse.momo.favorite.event;
 
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,17 +12,20 @@ import com.woowacourse.momo.group.event.GroupDeleteEvent;
 import com.woowacourse.momo.member.event.MemberDeleteEvent;
 
 @RequiredArgsConstructor
+@Transactional
 @Component
 public class FavoriteDeleteEventListener {
 
     private final FavoriteRepository favoriteRepository;
 
     @EventListener
+    @Async
     public void deleteGroup(GroupDeleteEvent event) {
         favoriteRepository.deleteAllByGroupId(event.getId());
     }
 
     @EventListener
+    @Async
     public void deleteMember(MemberDeleteEvent event) {
         favoriteRepository.deleteAllByMemberId(event.getId());
     }

--- a/backend/src/main/java/com/woowacourse/momo/global/config/AspectConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/AspectConfiguration.java
@@ -1,7 +1,5 @@
 package com.woowacourse.momo.global.config;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;

--- a/backend/src/main/java/com/woowacourse/momo/global/config/AsyncConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/AsyncConfiguration.java
@@ -1,0 +1,9 @@
+package com.woowacourse.momo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration {
+}

--- a/backend/src/main/java/com/woowacourse/momo/global/config/AsyncConfiguration.java
+++ b/backend/src/main/java/com/woowacourse/momo/global/config/AsyncConfiguration.java
@@ -1,9 +1,22 @@
 package com.woowacourse.momo.global.config;
 
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
 public class AsyncConfiguration {
+
+    @Bean
+    public Executor asyncThreadTaskExecutor() {
+        ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+        threadPoolTaskExecutor.setCorePoolSize(4);
+        threadPoolTaskExecutor.setMaxPoolSize(4);
+        threadPoolTaskExecutor.setThreadNamePrefix("momo-pool");
+        return threadPoolTaskExecutor;
+    }
 }

--- a/backend/src/test/java/com/woowacourse/momo/favorite/event/FavoriteDeleteEventListenerTest.java
+++ b/backend/src/test/java/com/woowacourse/momo/favorite/event/FavoriteDeleteEventListenerTest.java
@@ -2,6 +2,8 @@ package com.woowacourse.momo.favorite.event;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
 
 import static com.woowacourse.momo.fixture.GroupFixture.MOMO_STUDY;
 import static com.woowacourse.momo.fixture.GroupFixture.MOMO_TRAVEL;
@@ -16,7 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.jdbc.Sql;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,7 +31,8 @@ import com.woowacourse.momo.member.domain.Member;
 import com.woowacourse.momo.member.domain.MemberRepository;
 import com.woowacourse.momo.member.service.MemberService;
 
-@Transactional
+@Sql(value = "classpath:init.sql", executionPhase = BEFORE_TEST_METHOD)
+@Sql(value = "classpath:truncate.sql", executionPhase = AFTER_TEST_METHOD)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 @RequiredArgsConstructor
 @SpringBootTest


### PR DESCRIPTION
## ✨ Issue
- #548

## 🥇 구현한 기능
이벤트 처리 방식을 동기 -> 비동기로 수정

## 🧾 상세 내용
작업 관련 상세 내용은 아래의 블로그 게시글에 기록해뒀습니다.

📌 [모모팀 서비스 성능 개선기4 (비동기 처리를 통한 장애 전파 제거)](https://seongwon.dev/Spring/20221218-%EB%AA%A8%EB%AA%A8%ED%8C%80-%EC%84%9C%EB%B9%84%EC%8A%A4%EC%84%B1%EB%8A%A5-%EA%B0%9C%EC%84%A0%EA%B8%B04/)